### PR TITLE
Docs: Update README with EventType and enhanced constraints info

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,14 +73,30 @@ You can see a demo video of current features at https://www.atomiclife.app
 | ----------- | ----------- |
 | Semantic search | Use unique key phrases to match semantically similar past task events and apply them to new ones. Now your past tasks are templates for new ones! Apply duration, color, time preferences, priority, tags and more. Event details are converted into vectors and indexed for search. Note: You need to "train" Atomic on existing events to create event templates for new events. Read the [docs](https://docs.atomiclife.app) for more info. |
 | Automated tagging | Apply tags automatically using an AI model used for classification. Each tag comes with its own set of settings configured to apply to all matched events |
-| Flexible Meetings | Create recurring 1:1's or ad hoc team meetings that works with everyone's schedule. Every attendee's calendar is taken into account. Non-Atomic users can also sync their calendars and submit their time preferences. Once setup, your flexible recurring meetings occur automagically conflict free based on your time preferences.|
+| Flexible Meetings | Create recurring 1:1's or ad hoc team meetings that works with everyone's schedule. Every attendee's calendar is taken into account. Non-Atomic users can also sync their calendars and submit their time preferences. Once setup, your flexible recurring meetings occur automagically conflict free based on your time preferences. Scheduling logic now explicitly distinguishes between `ONE_ON_ONE_MEETING` and `GROUP_MEETING` types, applying tailored constraints for optimal placement.|
 | Autopilot | You can run the AI planner on Autopilot that will also search & apply features to new events based on past trained event templates. The AI planner will always run before your work day starts |
 |Time Preferences |Select time preferences for flexible meetings and other modifiable events |
 | Train events| You can train existing events and make them templates for new ones. Attributes you can change include transparency, buffer times, priority, time preferences, modifiable nature, tags, color, duration, break type, alarms. You can also "untrain" by turning "link off" in the event menu options.|
-| Time Blocking | You can automate time blockings of tasks that have a daily or weekly deadline with priority to let Atomic place them in the right place on your calendar. The deadlines can be soft or hard based on your requirements.|
+| Time Blocking | You can automate time blockings of tasks that have a daily or weekly deadline with priority to let Atomic place them in the right place on your calendar. The deadlines can be soft or hard based on your requirements. The system now uses a dedicated `TASK` event type, allowing for more specific scheduling rules, such as tasks spanning multiple days if needed, and respecting deadlines with refined constraints.|
 |Priority | You can set priority to modifiable events. Priority of 1 is neutral. 1 has no impact on the AI planner's decision making process. Any number > 1 will impact sooner it appears on the calendar relative other low priority events.|
 |Rating| You can rate events to tell Atomic how productive you were for the time block. Next run, Atomic will take it into consideration before the placing the event if it's modifiable|
 | Smart Tags | You can apply settings to tags. These settings will tell Atomic how to apply features or attributes to new events that are tagged by the AI model or manually.|
+
+### Granular Event Scheduling with EventType
+
+To provide more accurate and flexible calendar management, Atomic's scheduling engine now utilizes a refined `EventType` system. This allows for more tailored constraint application based on the specific nature of a calendar entry. The defined types are:
+
+*   **`TASK`**: For to-do items and work that needs to be scheduled. Tasks have specific constraints, such as respecting deadlines (with soft prioritization for earlier deadlines) and the ability to be scheduled across multiple days if necessary. They must always fall within defined working hours.
+*   **`ONE_ON_ONE_MEETING`**: For meetings between two individuals. Constraints ensure availability for both participants and that all parts of the meeting occur simultaneously.
+*   **`GROUP_MEETING`**: For meetings involving multiple participants. Similar to 1:1 meetings, it ensures all participants are available and scheduled for the same time slots.
+*   **`EVENT`**: For general calendar entries like appointments, conferences, or other reserved time blocks that might not fit the other categories.
+
+This `EventType`-aware approach means that the underlying OptaPlanner constraint provider can apply more nuanced rules. For example:
+    - Constraints that ensure all parts of an event occur on the same day are relaxed for `TASK` type events.
+    - Meeting-specific rules (like maximum number of meetings per day or back-to-back preferences) are now precisely applied only to `ONE_ON_ONE_MEETING` and `GROUP_MEETING` types.
+    - General scheduling rules, like conflict avoidance and respecting user-defined work hours, apply across all relevant event types.
+
+This enhancement leads to better schedule optimization and more intuitive handling of different kinds of calendar activities.
 
 #### Benefits of Self Hosted
 - Privacy enabled by default


### PR DESCRIPTION
I've updated the main README.md to reflect the recent enhancements to the scheduling engine, specifically:

-   Added details about the new `EventType` system (TASK,
    ONE_ON_ONE_MEETING, GROUP_MEETING, EVENT) to the Features section.
-   Clarified how different event types allow for more granular and
    specific constraint application (e.g., tasks spanning multiple days,
    dedicated rules for meetings).
-   Updated descriptions for "Time Blocking" and "Flexible Meetings"
    to mention the new event type distinctions.
-   Added a new subsection "Granular Event Scheduling with EventType"
    for a more detailed explanation of these improvements.