### PR TITLE
feat: Implement AWS Terraform and all base Kubernetes manifests

### DIFF
--- a/deploy/kubernetes/base/app/configmap.yaml
+++ b/deploy/kubernetes/base/app/configmap.yaml
@@ -4,159 +4,89 @@ metadata:
   name: app-configmap
   namespace: app
 data:
-  # Core Service URLs
-  NEXT_PUBLIC_HASURA_GRAPHQL_GRAPHQL_URL: "http://hasura-service.hasura.svc.cluster.local:8080/v1/graphql" # Internal for server-side calls if any, or use external below
-  NEXT_PUBLIC_HASURA_GRAPHQL_WS_URL: "ws://hasura-service.hasura.svc.cluster.local:8080/v1/graphql" # Internal WebSocket for Hasura
-  # For client-side (browser), these Hasura URLs should point to the externally exposed Hasura endpoint
-  NEXT_PUBLIC_EXTERNAL_HASURA_GRAPHQL_GRAPHQL_URL: "https://${HOST_NAME}/v1/graphql" # Placeholder for external Hasura
-  NEXT_PUBLIC_EXTERNAL_HASURA_GRAPHQL_WS_URL: "wss://${HOST_NAME}/v1/graphql" # Placeholder for external Hasura WS
+  # Core Application Settings
+  NODE_ENV: "production"
+  PORT: "3000" # Port the Next.js app runs on
+  LOG_LEVEL: "info" # Example log level
+  HOST_NAME: "your-app-domain.com" # Placeholder for actual external domain, used in other NEXT_PUBLIC_ URLs
 
-  NEXT_PUBLIC_FUNCTION_SERVER_URL: "http://functions-service.functions.svc.cluster.local:3000" # Internal URL for functions
-  # For client-side, functions might be exposed via an API gateway or directly
-  NEXT_PUBLIC_EXTERNAL_FUNCTION_SERVER_URL: "https://${HOST_NAME}/v1/functions" # Placeholder for external functions base URL
+  # NEXT_PUBLIC_ variables for client-side consumption
+  # These should point to externally accessible URLs or be general config values.
 
-  NEXT_PUBLIC_CHAT_WS_API_URL: "ws://functions-service.functions.svc.cluster.local:3030/chat" # Assuming chat is on port 3030 of functions, path /chat
-  # For client-side, chat WebSocket might be exposed via an API gateway or specific Ingress
-  NEXT_PUBLIC_EXTERNAL_CHAT_WS_API_URL: "wss://${HOST_NAME}/v1/chat-ws" # Placeholder for external chat WebSocket
+  # Hasura URLs (for client-side access, should be external endpoint)
+  NEXT_PUBLIC_HASURA_GRAPHQL_GRAPHQL_URL: "https://${HOST_NAME}/v1/graphql"
+  NEXT_PUBLIC_HASURA_GRAPHQL_WS_URL: "wss://${HOST_NAME}/v1/graphql" # Note: docker-compose had /v1/graphql, not /v1alpha1/graphql
 
-  # OAuth related URLs (pointing to the OAuth service, which would be externally exposed)
-  NEXT_PUBLIC_OAUTH_GOOGLE_LOGIN_URL: "https://${HOST_NAME}/v1/oauth/google" # Path on your oauth service
-  NEXT_PUBLIC_OAUTH_APPLE_LOGIN_URL: "https://${HOST_NAME}/v1/oauth/apple"   # Path on your oauth service
-  # These are often constructed by the app itself using NEXT_PUBLIC_OAUTH_BASE_URL or similar.
-  # Alternatively, provide the full paths if they are fixed.
+  # Functions Service related URLs (external endpoints)
+  NEXT_PUBLIC_FUNCTIONS_BASE_URL: "https://${HOST_NAME}/v1/functions" # Base for various function calls
+  NEXT_PUBLIC_CHAT_WS_API_URL: "wss://${HOST_NAME}/v1/functions/websocket" # WebSocket endpoint on functions service, exposed externally
 
-  # Handshake Service URL
-  NEXT_PUBLIC_ATOMIC_HANDSHAKE_API: "http://handshake-service.handshake.svc.cluster.local:3000/api" # Internal URL, assuming /api path
-  # For client-side, handshake API might be exposed via an API gateway or directly
-  NEXT_PUBLIC_EXTERNAL_ATOMIC_HANDSHAKE_API: "https://${HOST_NAME}/v1/handshake-api" # Placeholder for external handshake API
+  # Handshake API URL (external endpoint)
+  NEXT_PUBLIC_ATOMIC_HANDSHAKE_API: "https://${HOST_NAME}/v1/functions/handshake-api/createRecurMeetAssists/create-recur-meet-assists-public"
 
-  # S3/Storage URL
-  NEXT_PUBLIC_S3_ENDPOINT_URL: "http://minio-service.minio.svc.cluster.local:8484" # Internal Minio endpoint
-  NEXT_PUBLIC_S3_BUCKET_NAME: "atomic-assets" # Default bucket name
-  # For direct client-side uploads or access to public assets, an external Minio URL is needed
-  NEXT_PUBLIC_EXTERNAL_S3_PUBLIC_URL: "https://${MINIO_HOST_NAME}/${S3_BUCKET_NAME}" # Placeholder for external Minio URL
+  # OAuth related URLs (external endpoints of the OAuth service)
+  NEXT_PUBLIC_AUTH_URL: "https://${HOST_NAME}/v1/oauth" # Base URL for the OAuth service
 
-  # Zoom Integration related public variables (Client ID might come from here if truly public and not from ARG secret)
-  NEXT_PUBLIC_ZOOM_CLIENT_ID: "YOUR_PUBLIC_ZOOM_CLIENT_ID" # If different from the one in secrets or needs to be non-secret
-  NEXT_PUBLIC_ZOOM_REDIRECT_URL: "https://${HOST_NAME}/oauth/zoom/callback" # Callback path on your main app or oauth service
+  # Optaplanner API URL (external endpoint)
+  NEXT_PUBLIC_OPTAPLANNER_API_URL: "https://${HOST_NAME}/v1/optaplanner/api"
 
-  # General App Configuration
+  # S3/Storage related (external access if clients interact directly, or could be via functions)
+  # If clients upload/download directly, these need to be external MinIO URLs or presigned URLs from functions.
+  # For simplicity, providing a placeholder for an external images domain.
+  NEXT_PUBLIC_IMAGES_DOMAIN: "${HOST_NAME}" # Could be CDN or direct S3/Minio external URL base
+  # NEXT_PUBLIC_S3_ENDPOINT_URL: "https://${MINIO_HOST_NAME}" # If Minio has its own external domain
+  # NEXT_PUBLIC_S3_BUCKET_NAME: "atomic-assets"
+
+  # Zoom Integration (public client ID for frontend)
+  NEXT_PUBLIC_ZOOM_CLIENT_ID: "YOUR_PUBLIC_ZOOM_CLIENT_ID_PLACEHOLDER" # This might be same as secret ZOOM_CLIENT_ID or a different public one
+  NEXT_PUBLIC_ZOOM_REDIRECT_URL: "https://${HOST_NAME}/oauth/zoom/callback" # Callback to your app/oauth service
+
+  # Google OAuth (public client IDs for frontend)
+  # These are often public. If the ARGs in secret.yaml are for build-time and these are runtime for client, they can be here.
+  # If GOOGLE_CLIENT_ID_ATOMIC_WEB from secret is THE source, then this should be mapped from secret in deployment.
+  NEXT_PUBLIC_GOOGLE_CLIENT_ID_WEB: "YOUR_GOOGLE_CLIENT_ID_WEB_PLACEHOLDER_PUBLIC"
+  NEXT_PUBLIC_GOOGLE_CLIENT_ID_ATOMIC_WEB: "YOUR_GOOGLE_CLIENT_ID_ATOMIC_WEB_PLACEHOLDER_PUBLIC"
+
+  # External Services
+  NEXT_PUBLIC_POSTHOG_HOST: "https://app.posthog.com" # As per compose
+  NEXT_PUBLIC_POSTHOG_KEY: "" # Placeholder, fill if used. Usually public.
+  NEXT_PUBLIC_STRIPE_KEY: "" # Stripe Publishable Key. Placeholder, fill if used. Usually public.
+  NEXT_PUBLIC_CALCOM_URL: "https://cal.com" # As per compose
+
+  # General App Info & Links
   NEXT_PUBLIC_APP_NAME: "Atomic Entrepreneur"
-  NEXT_PUBLIC_APP_URL: "https://${HOST_NAME}" # The main external URL of this 'app' service
-  NEXT_PUBLIC_NODE_ENV: "production" # Or "development"
-  NEXT_PUBLIC_LOG_LEVEL: "info"
-  NEXT_PUBLIC_PORT: "3000" # Port the Next.js app runs on (for consistency, though client doesn't use this directly)
-  NEXT_PUBLIC_MAINTENANCE_MODE: "false"
-
-  # Feature Flags (examples)
-  NEXT_PUBLIC_ENABLE_FEATURE_X: "true"
-  NEXT_PUBLIC_ENABLE_FEATURE_Y: "false"
-
-  # Other miscellaneous public URLs or keys
+  NEXT_PUBLIC_APP_URL: "https://${HOST_NAME}" # Main external URL of this 'app' service
+  NEXT_PUBLIC_ENVIRONMENT: "production" # Client-side environment flag
+  NEXT_PUBLIC_SENTRY_DSN: "" # Sentry DSN for frontend error tracking. Placeholder.
+  NEXT_PUBLIC_SENTRY_ENVIRONMENT: "production"
+  NEXT_PUBLIC_GOOGLE_ANALYTICS_ID: "" # Google Analytics Tracking ID. Placeholder.
   NEXT_PUBLIC_TERMS_URL: "https://${HOST_NAME}/terms"
   NEXT_PUBLIC_PRIVACY_URL: "https://${HOST_NAME}/privacy"
   NEXT_PUBLIC_CONTACT_EMAIL: "support@example.com"
+  NEXT_PUBLIC_MAINTENANCE_MODE: "false"
 
-  # Note: ${HOST_NAME} and ${MINIO_HOST_NAME} are placeholders.
-  # These should be replaced with actual domain names, possibly via Ingress variables or CI/CD substitution.
-  # For internal service-to-service communication not directly from the client browser,
-  # use the Kubernetes FQDNs (e.g., functions-service.functions.svc.cluster.local:3000).
-  # NEXT_PUBLIC_ variables are embedded in the client-side bundle, so they must be resolvable by the browser.
-  # This means internal K8s FQDNs are only suitable for these if the client is also somehow within the cluster network (e.g. dev tools).
-  # For most NEXT_PUBLIC_ variables that point to backend services, they should use the external, publicly accessible URLs.
-  # I've provided both internal (e.g. NEXT_PUBLIC_HASURA_GRAPHQL_GRAPHQL_URL) and external
-  # (e.g. NEXT_PUBLIC_EXTERNAL_HASURA_GRAPHQL_GRAPHQL_URL) examples for clarity.
-  # The app's code would decide which one to use based on context (server-side vs client-side rendering/calls).
-  # For a pure SPA, all backend URLs would be external.
-  # For Next.js with SSR/API routes, it can use internal URLs for its server-side part and external for client-side part.
-  # The current setup primarily uses internal URLs for NEXT_PUBLIC_ variables,
-  # which implies the app's server-side part uses them or they are placeholders to be replaced.
-  # Let's adjust to make most NEXT_PUBLIC_ variables point to external placeholders for clarity,
-  # as they are intended for client-side consumption.
+  # Feature Flags (examples)
+  # NEXT_PUBLIC_ENABLE_FEATURE_X: "true"
 
-  # --- REVISED Approach for NEXT_PUBLIC_ variables ---
-  # All NEXT_PUBLIC_ variables are for client-side consumption, so they should point to public URLs.
-  # Server-side communication from the 'app' service's backend (API routes, SSR) to other internal services
-  # should use non-prefixed environment variables with K8s FQDNs. These would be defined in a separate configmap/secret
-  # or directly in the deployment if few, and not prefixed with NEXT_PUBLIC_.
-
-  # For this ConfigMap, we'll keep NEXT_PUBLIC_ variables and assume they are intended for external exposure.
-  # Redefining some critical ones to use ${HOST_NAME} or specific external paths.
-
-  NEXT_PUBLIC_HASURA_GRAPHQL_GRAPHQL_URL: "https://${HOST_NAME}/v1/graphql"
-  NEXT_PUBLIC_HASURA_GRAPHQL_WS_URL: "wss://${HOST_NAME}/v1/graphql"
-  NEXT_PUBLIC_FUNCTION_SERVER_URL: "https://${HOST_NAME}/v1/functions" # Base URL for functions exposed externally
-  NEXT_PUBLIC_CHAT_WS_API_URL: "wss://${HOST_NAME}/v1/chat-ws"
-  NEXT_PUBLIC_ATOMIC_HANDSHAKE_API: "https://${HOST_NAME}/v1/handshake-api" # Handshake API external endpoint
-  NEXT_PUBLIC_S3_PUBLIC_URL: "https://${MINIO_HOST_NAME}" # Base URL for Minio, bucket might be part of path or app logic
-
-  # Internal URLs for server-side use by the app service (if its API routes call other services)
-  # These should NOT be prefixed with NEXT_PUBLIC_
-  # Example:
+  # Internal URLs for server-side rendering (SSR) or API routes within the Next.js app, if needed.
+  # These should NOT be prefixed with NEXT_PUBLIC_ if they are only for server-side calls.
+  # Example (if 'app' service's backend/API routes call 'functions' service internally):
   INTERNAL_FUNCTIONS_URL: "http://functions-service.functions.svc.cluster.local:3000"
-  INTERNAL_HASURA_URL: "http://hasura-service.hasura.svc.cluster.local:8080/v1/graphql"
-  # These internal URLs would be added to a separate ConfigMap or directly to env vars in deployment if needed by app's backend.
-  # For now, this ConfigMap focuses on NEXT_PUBLIC_ variables as per the prompt's emphasis.
-  # The original list from compose had only NEXT_PUBLIC_ vars for 'app', so sticking to that.
+  INTERNAL_HASURA_GRAPHQL_URL: "http://hasura-service.hasura.svc.cluster.local:8080/v1/graphql"
+  # These are not used by default by NEXT_PUBLIC_ variables but can be used by the app's server-side logic.
+  # The original docker-compose for 'app' only listed NEXT_PUBLIC_ variables, so we primarily focus on those.
+  # Adding them here for completeness if the app's server-side logic needs them.
 
-  PLACEHOLDER_HOST_NAME: "localhost:8080" # Used by compose, for k8s this will be replaced by actual domain via Ingress
-  # Using HOST_NAME as a placeholder for the actual external domain.
-  # Using MINIO_HOST_NAME for Minio's external domain.
-  # These would typically be the same domain if behind a unified Ingress controller.
-  # Example: HOST_NAME=app.yourdomain.com, MINIO_HOST_NAME=minio.yourdomain.com or app.yourdomain.com/minio
+  # Placeholder for MinIO external host if different from main app host
+  MINIO_HOST_NAME: "minio.your-app-domain.com" # Example placeholder
 
-  # Keeping the original list structure from compose as much as possible for NEXT_PUBLIC_ variables:
-  NEXT_PUBLIC_AUTH_URL: "https://${HOST_NAME}/v1/oauth" # Assuming oauth service is externally at /v1/oauth
-  NEXT_PUBLIC_FUNCTIONS_BASE_URL: "https://${HOST_NAME}/v1/functions" # From compose
-  NEXT_PUBLIC_OPTAPLANNER_API_URL: "https://${HOST_NAME}/v1/optaplanner/api" # From compose
-  NEXT_PUBLIC_POSTHOG_HOST: "https://app.posthog.com" # From compose (external service)
-  NEXT_PUBLIC_POSTHOG_KEY: "" # From compose (this should probably be a secret if it's sensitive)
-  NEXT_PUBLIC_STRIPE_KEY: "" # From compose (Stripe public key, generally safe for client-side)
-  NEXT_PUBLIC_CALCOM_URL: "https://cal.com" # From compose (external service)
-  NEXT_PUBLIC_IMAGES_DOMAIN: "${HOST_NAME}" # Domain for images, could be CDN or Minio external
-  NEXT_PUBLIC_ENVIRONMENT: "production" # Or "development", "staging"
-  NEXT_PUBLIC_SENTRY_DSN: "" # Sentry DSN, should be secret if contains sensitive parts
-  NEXT_PUBLIC_SENTRY_ENVIRONMENT: "production"
-  NEXT_PUBLIC_GOOGLE_ANALYTICS_ID: ""
-  NEXT_PUBLIC_GOOGLE_CLIENT_ID_WEB: "YOUR_GOOGLE_CLIENT_ID_WEB_FROM_SECRET_OR_HERE" # Often public, can be here or from secret if ARG
-  NEXT_PUBLIC_GOOGLE_CLIENT_ID_ATOMIC_WEB: "YOUR_GOOGLE_CLIENT_ID_ATOMIC_WEB_FROM_SECRET_OR_HERE"
-
-  # Ensure HOST_NAME and MINIO_HOST_NAME are defined or substituted appropriately during deployment.
-  # For local k8s dev, these might be localhost with port-forwards, or minikube IPs.
-  # For cloud, these are your actual DNS names.
-  # The default value for ${HOST_NAME} could be set if there's a common one.
-  # For now, they are placeholders.
-  # Any variable that is truly an ARG passed to docker build and is sensitive should be in secret.yaml.
-  # NEXT_PUBLIC_GOOGLE_CLIENT_ID_WEB and NEXT_PUBLIC_GOOGLE_CLIENT_ID_ATOMIC_WEB are here as they are often public.
-  # If their values come from ARGs that are treated as secret (as in secret.yaml), the app should source them from there.
-  # This highlights a common confusion point: ARGs vs runtime env vars, and public vs secret.
-  # For NEXT_PUBLIC_ vars, values must be available at build time for static export, or runtime for SSR/CSR if not statically replaced.
-  # If these are runtime env vars for a server.js, then they are fine.
-  # Given it's a Next.js app, these are likely runtime envs for the server part or build-time for static parts.
-  # The Dockerfile ARGs listed in the secret.yaml for `app` were:
-  # HASURA_GRAPHQL_ADMIN_SECRET, GOOGLE_CLIENT_ID_ATOMIC_WEB, GOOGLE_CLIENT_SECRET_ATOMIC_WEB, ZOOM_IV_FOR_PASS, ZOOM_PASS_KEY.
-  # So, GOOGLE_CLIENT_ID_ATOMIC_WEB should be sourced from secret if it's the ARG.
-  # If NEXT_PUBLIC_GOOGLE_CLIENT_ID_ATOMIC_WEB is a *different* variable for client-side use, it's fine here.
-  # Assuming NEXT_PUBLIC_ prefixed ones here are distinct or public.
-  # If GOOGLE_CLIENT_ID_ATOMIC_WEB (from secret) is intended for NEXT_PUBLIC_GOOGLE_CLIENT_ID_ATOMIC_WEB,
-  # the deployment should map it. For now, keeping them separate as per typical Next.js patterns.
-  # (i.e. build ARGs might be different from runtime NEXT_PUBLIC_ vars)
-
-  # Final check on compose envs for 'app' service:
-  # HOST_NAME: "localhost:8080" -> placeholder, covered by ${HOST_NAME} concept
-  # MINIO_HOST_NAME: "localhost:9000" -> placeholder, covered by ${MINIO_HOST_NAME} concept
-  # All others are NEXT_PUBLIC_ and are included above.
-  # The values for POSTHOG_KEY, STRIPE_KEY, SENTRY_DSN, GOOGLE_ANALYTICS_ID are empty here,
-  # they should be filled or moved to secrets if sensitive. For now, they are as per compose (empty or placeholder).
-  # Public keys like Stripe publishable key are fine here. Sentry DSN sometimes is public, sometimes not.
-  # PostHog key is usually public.
-  PORT: "3000" # Consistent with other Next.js apps
-  NODE_ENV: "production" # Consistent
-  LOG_LEVEL: "info" # Consistent
-  # Adding HOST_NAME and MINIO_HOST_NAME as simple placeholders here for completeness,
-  # though they are more "meta" variables to be replaced by actual infrastructure values.
-  HOST_NAME_PLACEHOLDER: "app.yourdomain.com"
-  MINIO_HOST_NAME_PLACEHOLDER: "minio.yourdomain.com" # Or app.yourdomain.com/minio if using path-based routing
-  # These are not used by the app directly but represent the values that should replace ${HOST_NAME} etc.
-  # The app will use the NEXT_PUBLIC_ variables which *contain* these placeholders.
-  # The actual substitution into ${HOST_NAME} happens at deployment/Ingress config time.
+  # The variables like ${HOST_NAME} and ${MINIO_HOST_NAME} are conceptual placeholders.
+  # In a K8s setup, these would be actual domain names configured via Ingress and DNS.
+  # The ConfigMap stores the string with the placeholder; substitution happens elsewhere or
+  # the application is built to handle such placeholders if they are truly dynamic at runtime.
+  # For Next.js, these are typically build-time or server-runtime available. Client-side needs fully resolved URLs.
+  # Thus, for client-side (NEXT_PUBLIC_), the ${HOST_NAME} should ideally be resolved before the app consumes it,
+  # or the app itself constructs full URLs based on a single NEXT_PUBLIC_APP_URL.
+  # For this base configuration, we assume these values are provided at runtime to the server part of Next.js,
+  # and then made available to the client, or that build-time substitution happens.
+  # The `HOST_NAME` key here is for context; actual substitution into URLs must be handled.

--- a/deploy/kubernetes/base/app/deployment.yaml
+++ b/deploy/kubernetes/base/app/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: app
 spec:
-  replicas: 1 # Start with 1, can be scaled for a frontend application
+  replicas: 1 # As specified, can be scaled
   selector:
     matchLabels:
       app: app
@@ -17,63 +17,59 @@ spec:
     spec:
       containers:
         - name: app
-          image: "${PROJECT_NAME}-atomic-app:latest" # Placeholder - replace with actual image URL
+          image: "placeholder-atomic-app:latest" # Consistent placeholder name
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
-              containerPort: 3000 # Matches PORT in ConfigMap
+              containerPort: 3000 # Should match PORT in ConfigMap
               protocol: TCP
           envFrom:
             - secretRef:
                 name: app-secret
             - configMapRef:
                 name: app-configmap
-          # Environment variables from Dockerfile ARGs that are in secrets:
-          # These need to be explicitly mapped if their names in the secret are different
-          # from what the application expects, or if they are not covered by NEXT_PUBLIC_ prefixes.
-          # The Dockerfile ARGs for 'app' were:
-          # HASURA_GRAPHQL_ADMIN_SECRET, GOOGLE_CLIENT_ID_ATOMIC_WEB, GOOGLE_CLIENT_SECRET_ATOMIC_WEB, ZOOM_IV_FOR_PASS, ZOOM_PASS_KEY.
-          # These are in app-secret. If the application expects these exact env var names at runtime:
+          # Explicitly map Dockerfile ARGs from app-secret to ensure they are available
+          # with their original names if the application's build or runtime expects them directly,
+          # not just as NEXT_PUBLIC_ variables.
           env:
-            - name: HASURA_GRAPHQL_ADMIN_SECRET # If runtime needs it directly
+            - name: HASURA_GRAPHQL_ADMIN_SECRET # ARG from Dockerfile
               valueFrom:
                 secretKeyRef:
                   name: app-secret
                   key: HASURA_GRAPHQL_ADMIN_SECRET
-            - name: GOOGLE_CLIENT_ID_ATOMIC_WEB # If runtime needs it directly
+            - name: GOOGLE_CLIENT_ID_ATOMIC_WEB # ARG from Dockerfile
               valueFrom:
                 secretKeyRef:
                   name: app-secret
                   key: GOOGLE_CLIENT_ID_ATOMIC_WEB
-            - name: GOOGLE_CLIENT_SECRET_ATOMIC_WEB # If runtime needs it directly
+            - name: GOOGLE_CLIENT_SECRET_ATOMIC_WEB # ARG from Dockerfile
               valueFrom:
                 secretKeyRef:
                   name: app-secret
                   key: GOOGLE_CLIENT_SECRET_ATOMIC_WEB
-            - name: ZOOM_IV_FOR_PASS # If runtime needs it directly
+            - name: ZOOM_IV_FOR_PASS # ARG from Dockerfile
               valueFrom:
                 secretKeyRef:
                   name: app-secret
                   key: ZOOM_IV_FOR_PASS
-            - name: ZOOM_PASS_KEY # If runtime needs it directly
+            - name: ZOOM_PASS_KEY # ARG from Dockerfile
               valueFrom:
                 secretKeyRef:
                   name: app-secret
                   key: ZOOM_PASS_KEY
-            # Note: NEXT_PUBLIC_GOOGLE_CLIENT_ID_ATOMIC_WEB is in the configmap.
-            # If this should be the same as GOOGLE_CLIENT_ID_ATOMIC_WEB from the secret,
-            # then that NEXT_PUBLIC_ variable in configmap should rather be set here from the secret.
-            # Example:
+            # Note: The ConfigMap contains NEXT_PUBLIC_GOOGLE_CLIENT_ID_ATOMIC_WEB.
+            # If this should be the *same value* as the ARG GOOGLE_CLIENT_ID_ATOMIC_WEB from the secret,
+            # then the ConfigMap entry is redundant, and the Next.js app should be configured
+            # to use GOOGLE_CLIENT_ID_ATOMIC_WEB (from secret) for its NEXT_PUBLIC_GOOGLE_CLIENT_ID_ATOMIC_WEB build process.
+            # Or, this env var can be set here to override the ConfigMap one:
             # - name: NEXT_PUBLIC_GOOGLE_CLIENT_ID_ATOMIC_WEB
             #   valueFrom:
             #     secretKeyRef:
             #       name: app-secret
             #       key: GOOGLE_CLIENT_ID_ATOMIC_WEB
-            # For now, assuming the NEXT_PUBLIC_ one in configmap is separate or correctly sourced during build.
+            # For now, assuming the explicit ARG env vars are needed by the build/runtime,
+            # and NEXT_PUBLIC_ vars in configmap are for client-side values (which might be same or different).
 
-
-          # Probes: Next.js apps in standalone mode usually serve on '/'.
-          # If a specific health check endpoint is available (e.g., /api/health), use that.
           readinessProbe:
             httpGet:
               path: / # Check root path, or a specific health endpoint

--- a/deploy/kubernetes/base/app/kustomization.yaml
+++ b/deploy/kubernetes/base/app/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: app
+namespace: app # Sets the namespace for all resources in this kustomization
 
 resources:
   - namespace.yaml
@@ -10,11 +10,13 @@ resources:
   - deployment.yaml
   - service.yaml
 
-# Optional: Add common labels to all resources
+# Optional: Add common labels to all resources defined in this kustomization
 # commonLabels:
-#   app.kubernetes.io/name: app
+#   app.kubernetes.io/name: main-app
+#   app.kubernetes.io/instance: app
+#   app.kubernetes.io/component: frontend
 #   app.kubernetes.io/part-of: atomic-stack
 
 # Optional: Add common annotations
 # commonAnnotations:
-#   source: "https://github.com/your-repo/atomic-stack"
+#   note: "Main frontend application base configuration"

--- a/deploy/kubernetes/base/app/secret.yaml
+++ b/deploy/kubernetes/base/app/secret.yaml
@@ -5,19 +5,15 @@ metadata:
   namespace: app
 type: Opaque
 data:
-  # Hasura Admin Secret (if direct privileged access is needed by the app, though unlikely for a frontend)
-  # It's listed as an ARG, so including it. Could be for build-time operations.
-  HASURA_GRAPHQL_ADMIN_SECRET: bXlhZG1pbnNlY3JldGtleQ== # "myadminsecretkey" (ensure this matches Hasura's actual admin secret)
+  # Secrets derived from Dockerfile ARGs for the 'app' service
+  HASURA_GRAPHQL_ADMIN_SECRET: bXlhZG1pbnNlY3JldGtleQ== # "myadminsecretkey" (Ensure this matches Hasura's actual admin secret if used at runtime)
 
-  # Google OAuth Client for Atomic Web (assuming 'app' is the atomic-app)
   GOOGLE_CLIENT_ID_ATOMIC_WEB: cGxhY2Vob2xkZXJfdmFsdWU= # "placeholder_value"
   GOOGLE_CLIENT_SECRET_ATOMIC_WEB: cGxhY2Vob2xkZXJfdmFsdWU= # "placeholder_value"
 
-  # Zoom Encryption Keys (if used by frontend, though more typical in backend)
-  # Listed as ARGs, so including them.
-  ZOOM_IV_FOR_PASS: cGxhY2Vob2xkZXJfdmFsdWU=
-  ZOOM_PASS_KEY: cGxhY2Vob2xkZXJfdmFsdWU=
+  ZOOM_IV_FOR_PASS: cGxhY2Vob2xkZXJfdmFsdWU= # "placeholder_value"
+  ZOOM_PASS_KEY: cGxhY2Vob2xkZXJfdmFsdWU= # "placeholder_value"
 
-  # Any other sensitive ARGs or runtime needs for the app service
-  # For example, if the app uses its own session secret or API keys for other services
-  APP_SPECIFIC_API_KEY: cGxhY2Vob2xkZXJfdmFsdWU= # Example if app needs its own API key for something
+  # Add any other sensitive runtime environment variables the 'app' service might need.
+  # For example, if it directly calls a service requiring an API key not covered by NEXT_PUBLIC_ variables.
+  # INTERNAL_SERVICE_API_KEY: cGxhY2Vob2xkZXJfdmFsdWU=

--- a/deploy/kubernetes/base/app/service.yaml
+++ b/deploy/kubernetes/base/app/service.yaml
@@ -6,11 +6,11 @@ metadata:
   labels:
     app: app
 spec:
-  type: ClusterIP
+  type: ClusterIP # Internal service; will be exposed via Ingress externally
   selector:
     app: app # Selects the app pods
   ports:
     - name: http
       protocol: TCP
-      port: 3000 # Port the service will listen on
-      targetPort: http # Name of the port in the Deployment's podSpec (containerPort 3000)
+      port: 3000       # Port the service will listen on
+      targetPort: http # Matches the 'http' port name in the Deployment's podSpec (containerPort 3000)

--- a/deploy/kubernetes/base/functions/configmap.yaml
+++ b/deploy/kubernetes/base/functions/configmap.yaml
@@ -4,81 +4,55 @@ metadata:
   name: functions-configmap
   namespace: functions
 data:
-  NODE_ENV: "production" # Or "development", "staging" as appropriate for the base
-  FUNCTION_SERVER_URL: "http://functions-service.functions.svc.cluster.local:3000"
-  APP_CLIENT_URL: "http://your-frontend-app-url.com" # Placeholder: replace with actual client URL or K8s service if applicable
-  HANDSHAKE_URL: "http://your-handshake-service-url.com" # Placeholder: replace or use K8s service
-  GOOGLE_CALENDAR_WEBHOOK_URL: "https://your-domain.com/api/google/calendar/webhook" # Needs external exposure or specific setup
+  # Core Application Settings
+  NODE_ENV: "production"
+  LOG_LEVEL: "info"
+  PORT: "3000" # Main port for the functions service
+  PORT_SECONDARY: "3030" # Secondary port (e.g., for WebSockets, as seen in compose)
+  FUNCTION_SERVER_URL: "http://functions-service.functions.svc.cluster.local:3000" # Self-reference for internal calls if needed
 
-  # Hasura Configuration
+  # External URL Placeholders (to be replaced by actual domain names, e.g., via Ingress)
+  APP_CLIENT_URL: "https://${HOST_NAME}" # Main frontend application URL
+  HANDSHAKE_URL: "https://${HOST_NAME}/v1/handshake" # External URL for handshake service/endpoint
+  OAUTH_REDIRECT_URL: "https://${HOST_NAME}/v1/oauth/callback" # Example generic OAuth callback
+  GOOGLE_CALENDAR_WEBHOOK_URL: "https://${HOST_NAME}/api/google/calendar/webhook" # Example webhook URL exposed by this functions service
+
+  # Internal Service Discovery URLs
   HASURA_GRAPHQL_GRAPHQL_URL: "http://hasura-service.hasura.svc.cluster.local:8080/v1/graphql"
-  # HASURA_GRAPHQL_URL is often used as an alias for HASURA_GRAPHQL_GRAPHQL_URL by some tools/sdks
-  HASURA_GRAPHQL_URL: "http://hasura-service.hasura.svc.cluster.local:8080"
+  HASURA_GRAPHQL_URL: "http://hasura-service.hasura.svc.cluster.local:8080" # Base Hasura URL
 
+  S3_ENDPOINT: "http://minio-service.minio.svc.cluster.local:8484" # Internal MinIO S3 endpoint
+  S3_BUCKET: "atomic-assets" # Default bucket name
+  # S3_PUBLIC_URL: "http://minio-service.minio.svc.cluster.local:8484/atomic-assets" # Or external if Minio is exposed
 
-  # Storage (Minio/S3) Configuration
-  S3_ENDPOINT: "http://minio-service.minio.svc.cluster.local:8484" # Internal Minio endpoint
-  S3_BUCKET: "atomic-assets" # Default bucket name, make sure it's created in Minio
-  S3_PUBLIC_URL: "http://minio-service.minio.svc.cluster.local:8484/atomic-assets" # Or external Minio URL if exposed
+  KAFKA_BOOTSTRAP_SERVERS: "kafka-service.kafka.svc.cluster.local:9092" # Kafka brokers
+  # KAFKA_SCHEMA_REGISTRY_URL: "http://schema-registry-service.kafka.svc.cluster.local:8081" # If using Schema Registry
 
-  # Kafka Configuration
-  KAFKA_BROKERS: "kafka-service.kafka.svc.cluster.local:9092" # List of Kafka brokers
-  KAFKA_SCHEMA_REGISTRY_URL: "http://schema-registry-service.kafka.svc.cluster.local:8081" # If using Schema Registry
-  # KAFKA_CONSUMER_GROUP_ID: "functions-group" # Example consumer group
+  OPENSEARCH_ENDPOINT: "http://opensearch-service.opensearch.svc.cluster.local:9200" # OpenSearch endpoint
 
-  # OpenSearch Configuration
-  OPENSEARCH_URL: "http://opensearch-service.opensearch.svc.cluster.local:9200" # OpenSearch endpoint
+  OPTAPLANNER_URL: "http://optaplanner-service.optaplanner.svc.cluster.local:8081" # Optaplanner service endpoint
 
-  # Optaplanner Configuration
-  OPTAPLANNER_URL: "http://optaplanner-service.optaplanner.svc.cluster.local:8080" # Optaplanner endpoint (assuming it has a similar service structure)
-  # If Optaplanner is one of the java-services, the name might be different, e.g., java-atomic-optaplanner-service
+  # Supertokens (if functions service needs to call Supertokens core directly)
+  SUPERTOKENS_CORE_URL: "http://supertokens-service.supertokens.svc.cluster.local:3567"
 
-  # Rate Limiting (example, if used)
-  # RATE_LIMIT_WINDOW_MS: "60000"
-  # RATE_LIMIT_MAX_REQUESTS: "100"
+  # Redis (if used)
+  # REDIS_URL: "redis://redis-service.redis.svc.cluster.local:6379"
 
-  # Other non-sensitive configurations
-  LOG_LEVEL: "info" # Or "debug", "warn", "error"
-  PORT: "3000" # Main application port
-  PORT_SECONDARY: "3030" # Secondary port, if used by the application
-
-  # Timezone
+  # Other non-sensitive configurations from docker-compose or app needs
   TZ: "UTC"
+  # CORS settings might be here if not hardcoded
+  # CORS_ORIGIN: "https://${HOST_NAME},http://localhost:3001" # Example
 
-  # CORS settings (example)
-  # CORS_ORIGIN: "http://localhost:3001,https://your-app.com"
-  # CORS_METHODS: "GET,POST,PUT,DELETE,PATCH,OPTIONS"
-  # CORS_ALLOWED_HEADERS: "Content-Type,Authorization"
+  # Nhost specific variables from compose, if non-sensitive and needed by functions directly.
+  # Many NHOST_ variables are for configuring Nhost's services themselves or are aliases.
+  # NHOST_SERVER_URL: "http://localhost:1337" # Example from compose, likely dev only.
+  # NHOST_CONSOLE_URL: "http://localhost:9000" # Example from compose, likely dev only.
+  # These are omitted as they seem like local development URLs for other Nhost services,
+  # not direct configurations for this 'functions' microservice in a K8s context.
+  # If there are specific non-sensitive NHOST_ variables that this 'functions' service consumes, they should be added.
 
-  # Redis (if used, example)
-  # REDIS_HOST: "redis-service.redis.svc.cluster.local"
-  # REDIS_PORT: "6379"
+  # Placeholder for the external host name, which will be substituted by Ingress or other mechanisms
+  HOST_NAME: "your-app-domain.com" # Example placeholder, actual value depends on deployment
 
-  # These are just examples; the actual needed non-sensitive variables depend on the functions service implementation.
-  # The list from docker-compose.yaml for 'functions' should be reviewed for any other non-sensitive vars.
-  NHOST_ADMIN_SECRET: "admin-secret-from-compose-but-should-be-in-secret" # This was in compose, but name implies secret. Moved to secret.yaml as HASURA_GRAPHQL_ADMIN_SECRET
-  NHOST_WEBHOOK_SECRET: "webhook-secret-from-compose-but-should-be-in-secret" # Likewise
-  NHOST_JWT_SECRET: "jwt-secret-from-compose-but-should-be-in-secret" # Likewise (related to Hasura JWT)
-
-  # These were in docker-compose for functions, ensure they are correctly mapped:
-  # Some of these are clearly dependent on other services being named consistently in K8s.
-  # HASURA_GRAPHQL_ADMIN_SECRET -> in secret.yaml
-  # HASURA_GRAPHQL_DATABASE_URL -> constructed in deployment from secret parts
-  # HASURA_GRAPHQL_JWT_SECRET -> in secret.yaml
-  # HASURA_GRAPHQL_UNAUTHORIZED_ROLE -> this is a Hasura config, not directly for functions, but functions might need to know it.
-  # For now, assuming functions doesn't need HASURA_GRAPHQL_UNAUTHORIZED_ROLE directly.
-
-  # Variables like NHOST_... from the compose file seem to be for Nhost's own control plane or specific Nhost CLI behavior.
-  # If the 'functions' service is a generic microservice, it might not need Nhost-specific variables like NHOST_ADMIN_SECRET,
-  # NHOST_WEBHOOK_SECRET, unless it's specifically interacting with an Nhost control plane.
-  # Given Hasura admin/JWT secrets are already covered, these NHOST_ prefixed ones might be redundant or for a different context.
-  # I will omit NHOST_ prefixed variables from the ConfigMap for now, assuming their roles are covered by more standard
-  # variable names (like HASURA_GRAPHQL_ADMIN_SECRET for Hasura interaction).
-  # If they are truly distinct and non-sensitive, they can be added here.
-  # The docker-compose used NHOST_ variables which often alias to Hasura ones.
-
-  # Ensure all URLs point to the correct K8s internal service names and namespaces.
-  # Example: `optaplanner-service.optaplanner.svc.cluster.local` assumes an `optaplanner` namespace and `optaplanner-service`.
-  # Adjust these if your service naming or namespace structure is different.
-  # For services within the SAME namespace as `functions`, you can use the short form: e.g. `http://my-other-service:port`
-  # This ConfigMap assumes services are in their own dedicated namespaces as per previous steps.
+  # Ensure all necessary non-sensitive environment variables from the 'functions' service
+  # in the docker-compose.yaml are represented here, adapted for Kubernetes internal service discovery.

--- a/deploy/kubernetes/base/functions/deployment.yaml
+++ b/deploy/kubernetes/base/functions/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: functions
 spec:
-  replicas: 1 # Start with 1, can be scaled
+  replicas: 1 # As specified, can be scaled
   selector:
     matchLabels:
       app: functions
@@ -17,32 +17,28 @@ spec:
     spec:
       containers:
         - name: functions
-          image: "${PROJECT_NAME}-atomic-functions:latest" # Placeholder - replace with actual image URL
-          imagePullPolicy: IfNotPresent # Or Always if using 'latest' tag frequently
+          image: "placeholder-atomic-functions:latest" # Consistent placeholder name
+          imagePullPolicy: IfNotPresent # Or "Always" if using :latest frequently in dev
           ports:
-            - name: main
-              containerPort: 3000
+            - name: main # Main application port
+              containerPort: 3000 # Should match PORT in ConfigMap
               protocol: TCP
-            - name: secondary
-              containerPort: 3030
+            - name: secondary # Secondary port (e.g., for WebSockets)
+              containerPort: 3030 # Should match PORT_SECONDARY in ConfigMap
               protocol: TCP
           envFrom:
             - secretRef:
                 name: functions-secret
             - configMapRef:
                 name: functions-configmap
-          # Individual env vars can also be set here if they need specific formatting
-          # or are not part of the bulk import from secret/configmap.
-          # Example:
-          # - name: MY_CUSTOM_VARIABLE
-          #   value: "some_specific_value"
+          # No individual 'env:' mappings here unless specific overrides or formatting are needed,
+          # as most should be covered by functions-secret and functions-configmap.
 
-          # Probes should target the main port (3000) or a specific health check endpoint and port.
           readinessProbe:
             httpGet:
-              path: /healthz # Assuming a /healthz endpoint exists
-              port: main # Port 3000
-            initialDelaySeconds: 10
+              path: /healthz # Assuming a standard /healthz endpoint
+              port: main    # Main port 3000
+            initialDelaySeconds: 15 # Allow more time for functions service with many connections
             periodSeconds: 15
             timeoutSeconds: 5
             failureThreshold: 3
@@ -50,15 +46,14 @@ spec:
             httpGet:
               path: /healthz
               port: main
-            initialDelaySeconds: 30
+            initialDelaySeconds: 45 # More conservative for liveness
             periodSeconds: 30
             timeoutSeconds: 5
             failureThreshold: 3
-          # Volume mounts if needed for persistent data (not typical for stateless functions unless specified)
+          # Volume mounts if needed (e.g., for temporary file storage if functions process files)
           # volumeMounts:
-          #   - name: functions-data
-          #     mountPath: /data
+          #   - name: temp-storage
+          #     mountPath: /tmp
       # volumes:
-      #   - name: functions-data
-      #     persistentVolumeClaim:
-      #       claimName: functions-pvc # If a PVC named 'functions-pvc' is defined
+      #   - name: temp-storage
+      #     emptyDir: {} # Example of an emptyDir volume for temporary data

--- a/deploy/kubernetes/base/functions/kustomization.yaml
+++ b/deploy/kubernetes/base/functions/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: functions
+namespace: functions # Sets the namespace for all resources in this kustomization
 
 resources:
   - namespace.yaml
@@ -10,11 +10,13 @@ resources:
   - deployment.yaml
   - service.yaml
 
-# Optional: Add common labels to all resources
+# Optional: Add common labels to all resources defined in this kustomization
 # commonLabels:
 #   app.kubernetes.io/name: functions
-#   app.kubernetes.io/part-of: atomic-stack
+#   app.kubernetes.io/instance: functions
+#   app.kubernetes.io/component: backend-service
+#   app.kubernetes.io/part-of: atomic-stack # Or your specific application/project name
 
 # Optional: Add common annotations
 # commonAnnotations:
-#   source: "https://github.com/your-repo/atomic-stack"
+#   note: "Functions microservice base configuration"

--- a/deploy/kubernetes/base/functions/secret.yaml
+++ b/deploy/kubernetes/base/functions/secret.yaml
@@ -5,140 +5,84 @@ metadata:
   namespace: functions
 type: Opaque
 data:
-  # Basic Auth & General API Keys
-  BASIC_AUTH: YWRtaW46cGFzc3dvcmQ= # "admin:password"
-  OPENAI_API_KEY: YOUR_OPENAI_API_KEY_HERE_ENCODED # Replace with actual encoded key later
-  API_TOKEN: YOUR_API_TOKEN_HERE_ENCODED # e.g., for Optaplanner, same as OPTAPLANNER_PASSWORD
+  # Authentication & Authorization
+  BASIC_AUTH: YWRtaW46cGFzc3dvcmQ= # "admin:password" Placeholder for functions -admin endpoints
+  HASURA_GRAPHQL_ADMIN_SECRET: bXlhZG1pbnNlY3JldGtleQ== # "myadminsecretkey" To interact with Hasura with admin rights
+  API_TOKEN: cGxhY2Vob2xkZXJfdmFsdWU= # Generic API token, potentially for Optaplanner or other services
 
-  # Hasura Integration
-  HASURA_GRAPHQL_ADMIN_SECRET: bXlhZG1pbnNlY3JldGtleQ== # "myadminsecretkey" (ensure this matches Hasura's actual admin secret)
-
-  # Google OAuth & Services
-  GOOGLE_CLIENT_ID_ANDROID: YOUR_GOOGLE_CLIENT_ID_ANDROID_ENCODED
-  GOOGLE_CLIENT_ID_IOS: YOUR_GOOGLE_CLIENT_ID_IOS_ENCODED
-  GOOGLE_CLIENT_ID_WEB: YOUR_GOOGLE_CLIENT_ID_WEB_ENCODED
-  GOOGLE_CLIENT_ID_ATOMIC_WEB: YOUR_GOOGLE_CLIENT_ID_ATOMIC_WEB_ENCODED
-  GOOGLE_CLIENT_SECRET_ATOMIC_WEB: YOUR_GOOGLE_CLIENT_SECRET_ATOMIC_WEB_ENCODED
-  GOOGLE_CLIENT_SECRET_WEB: YOUR_GOOGLE_CLIENT_SECRET_WEB_ENCODED
-  GOOGLE_CALENDAR_ID: YOUR_GOOGLE_CALENDAR_ID_ENCODED
-  GOOGLE_CALENDAR_CREDENTIALS: BASE64_ENCODED_GOOGLE_CALENDAR_CREDENTIALS_JSON # Credentials JSON for service account or OAuth client
-  GOOGLE_MAP_KEY: YOUR_GOOGLE_MAP_KEY_ENCODED
-  GOOGLE_PLACE_API_KEY: YOUR_GOOGLE_PLACE_API_KEY_ENCODED
-
-  # Storage (Minio/S3)
-  STORAGE_ACCESS_KEY: bWluaW9hZG1pbg== # "minioadmin" (ensure this matches Minio's root user or a dedicated user)
-  STORAGE_SECRET_KEY: bWluaW8xMjM= # "minio123" (ensure this matches Minio's root password or dedicated user's password)
-  STORAGE_REGION: dXMtZWFzdC0x # "us-east-1" (example region)
-
-  # Kafka Credentials (if SASL is used; otherwise, these might not be needed for PLAINTEXT)
-  KAFKA_USERNAME: YOUR_KAFKA_USERNAME_ENCODED # "user1"
-  KAFKA_PASSWORD: YOUR_KAFKA_PASSWORD_ENCODED # "password123"
-
-  # OpenSearch Credentials (if security plugin is enabled; otherwise, not needed for base non-secure OpenSearch)
-  OPENSEARCH_USERNAME: YOUR_OPENSEARCH_USERNAME_ENCODED # "admin"
-  OPENSEARCH_PASSWORD: YOUR_OPENSEARCH_PASSWORD_ENCODED # "admin"
-
-  # Zoom Integration
-  ZOOM_PASS_KEY: YOUR_ZOOM_PASS_KEY_ENCODED
-  ZOOM_CLIENT_ID: YOUR_ZOOM_CLIENT_ID_ENCODED
-  ZOOM_SALT_FOR_PASS: YOUR_ZOOM_SALT_FOR_PASS_ENCODED
-  ZOOM_IV_FOR_PASS: YOUR_ZOOM_IV_FOR_PASS_ENCODED
-  ZOOM_CLIENT_SECRET: YOUR_ZOOM_CLIENT_SECRET_ENCODED
-  ZOOM_WEBHOOK_SECRET_TOKEN: YOUR_ZOOM_WEBHOOK_SECRET_TOKEN_ENCODED
-  NEXT_PUBLIC_ZOOM_CLIENT_ID: YOUR_NEXT_PUBLIC_ZOOM_CLIENT_ID_ENCODED # This seems like a frontend var, but listed in functions env
-
-  # Optaplanner Credentials
-  OPTAPLANNER_USERNAME: YOUR_OPTAPLANNER_USERNAME_ENCODED # "admin"
-  OPTAPLANNER_PASSWORD: YOUR_OPTAPLANNER_PASSWORD_ENCODED # "admin" (often same as API_TOKEN)
-
-  # SMTP / Email
-  SMTP_HOST: YOUR_SMTP_HOST_ENCODED # "smtp.example.com"
-  SMTP_PORT: NTI1 # "587" or "465" / "25"
-  SMTP_USER: YOUR_SMTP_USER_ENCODED # "user@example.com"
-  SMTP_PASS: YOUR_SMTP_PASSWORD_ENCODED # "smtppassword"
-  SMTP_FROM_EMAIL: YOUR_SMTP_FROM_EMAIL_ENCODED # "noreply@example.com"
-
-  # Twilio
-  TWILIO_ACCOUNT_SID: YOUR_TWILIO_ACCOUNT_SID_ENCODED
-  TWILIO_AUTH_TOKEN: YOUR_TWILIO_AUTH_TOKEN_ENCODED
-  TWILIO_PHONE_NO: YOUR_TWILIO_PHONE_NO_ENCODED
-
-  # Stripe
-  STRIPE_API_KEY: YOUR_STRIPE_API_KEY_ENCODED
-  STRIPE_WEBHOOK_SECRET: YOUR_STRIPE_WEBHOOK_SECRET_ENCODED
-
-  # Other External Services / Misc
-  ONESIGNAL_APP_ID: YOUR_ONESIGNAL_APP_ID_ENCODED
-  ONESIGNAL_REST_API_KEY: YOUR_ONESIGNAL_REST_API_KEY_ENCODED
-  SLACK_BOT_TOKEN: YOUR_SLACK_BOT_TOKEN_ENCODED
-  SLACK_SIGNING_SECRET: YOUR_SLACK_SIGNING_SECRET_ENCODED
-  SLACK_CHANNEL_ID: YOUR_SLACK_CHANNEL_ID_ENCODED
-  NODE_ENV: cHJvZHVjdGlvbg== # "production" (can also be in ConfigMap if not sensitive)
-  JWT_SECRET: YOUR_JWT_SECRET_KEY_HERE_ENCODED # General JWT secret if used by functions directly
-  ENCRYPTION_KEY: YOUR_ENCRYPTION_KEY_HERE_ENCODED # General encryption key
-
-  # Placeholder for any missing secrets, use simple base64 encoded "value"
-  # For example, 'YOUR_OPENAI_API_KEY_HERE_ENCODED' should be the base64 of "YOUR_OPENAI_API_KEY_HERE"
-  # "YOUR_OPENAI_API_KEY_HERE" -> WU9VUl9PUEVOQUlfQVBJX0tFWV9IRVJFX0VOQ09ERUQ=
-  # To avoid making this initial generation too complex, I've used descriptive placeholder names.
-  # These would be replaced by actual base64 encoded secret values in a real setup.
-  # For now, I'll use a generic encoded placeholder for those not explicitly given.
-  # Generic placeholder "VALUE" -> VkFMVUU=
-  PLACEHOLDER_SECRET: VkFMVUU=
-
-# Note: For actual deployment, each placeholder like 'YOUR_OPENAI_API_KEY_HERE_ENCODED'
-# must be replaced with the *actual base64 encoded secret value*.
-# Example for OPENAI_API_KEY: if key is "sk-123", base64 is "c2stMTIz".
-# The current values are descriptive placeholders, not actual encoded values of those descriptions.
-# I will update a few common ones to reflect actual encoding of a placeholder string.
-# For example, for OPENAI_API_KEY, if the placeholder string is "openai_api_key_placeholder",
-# its base64 is "b3BlbmFpX2FwaV9rZXlfcGxhY2Vob2xkZXI=". I will use this pattern for a few.
-
-# Re-encoding some common placeholders with "placeholder_value" as the string:
-# "placeholder_value" -> cGxhY2Vob2xkZXJfdmFsdWU=
-# This will be used for keys that don't have a more specific placeholder from the prompt.
-
-# Overwriting some with a generic encoded placeholder:
-# (This is illustrative; in a real scenario, each would be unique)
+  # Cloud & AI Services
   OPENAI_API_KEY: cGxhY2Vob2xkZXJfdmFsdWU=
-  API_TOKEN: cGxhY2Vob2xkZXJfdmFsdWU=
+
+  # Google OAuth & Services (placeholders, ensure these are specific to the 'functions' service needs if different from 'app' or 'oauth' services)
   GOOGLE_CLIENT_ID_ANDROID: cGxhY2Vob2xkZXJfdmFsdWU=
   GOOGLE_CLIENT_ID_IOS: cGxhY2Vob2xkZXJfdmFsdWU=
   GOOGLE_CLIENT_ID_WEB: cGxhY2Vob2xkZXJfdmFsdWU=
-  GOOGLE_CLIENT_ID_ATOMIC_WEB: cGxhY2Vob2xkZXJfdmFsdWU=
-  GOOGLE_CLIENT_SECRET_ATOMIC_WEB: cGxhY2Vob2xkZXJfdmFsdWU=
   GOOGLE_CLIENT_SECRET_WEB: cGxhY2Vob2xkZXJfdmFsdWU=
+  # GOOGLE_CLIENT_ID_ATOMIC_WEB was in previous 'functions' secret, assuming covered by general 'WEB' or distinct if needed.
+  # GOOGLE_CLIENT_SECRET_ATOMIC_WEB was in previous 'functions' secret.
   GOOGLE_CALENDAR_ID: cGxhY2Vob2xkZXJfdmFsdWU=
-  GOOGLE_CALENDAR_CREDENTIALS: cGxhY2Vob2xkZXJfdmFsdWU=
+  GOOGLE_CALENDAR_CREDENTIALS: cGxhY2Vob2xkZXJfdmFsdWU= # Base64 encoded JSON string
   GOOGLE_MAP_KEY: cGxhY2Vob2xkZXJfdmFsdWU=
   GOOGLE_PLACE_API_KEY: cGxhY2Vob2xkZXJfdmFsdWU=
+
+  # Storage (Minio/S3)
+  STORAGE_ACCESS_KEY: bWluaW9hZG1pbg== # "minioadmin" (MinIO root user for internal S3)
+  STORAGE_SECRET_KEY: bWluaW8xMjM=     # "minio123" (MinIO root password)
+  STORAGE_REGION: dXMtZWFzdC0x         # "us-east-1" (Example region)
+
+  # Kafka Credentials (if functions service interacts with Kafka using SASL)
   KAFKA_USERNAME: cGxhY2Vob2xkZXJfdmFsdWU=
   KAFKA_PASSWORD: cGxhY2Vob2xkZXJfdmFsdWU=
+
+  # OpenSearch Credentials (if functions service interacts with secured OpenSearch)
   OPENSEARCH_USERNAME: cGxhY2Vob2xkZXJfdmFsdWU=
   OPENSEARCH_PASSWORD: cGxhY2Vob2xkZXJfdmFsdWU=
-  ZOOM_PASS_KEY: cGxhY2Vob2xkZXJfdmFsdWU=
+
+  # Zoom Integration
   ZOOM_CLIENT_ID: cGxhY2Vob2xkZXJfdmFsdWU=
+  ZOOM_CLIENT_SECRET: cGxhY2Vob2xkZXJfdmFsdWU=
+  ZOOM_PASS_KEY: cGxhY2Vob2xkZXJfdmFsdWU=
   ZOOM_SALT_FOR_PASS: cGxhY2Vob2xkZXJfdmFsdWU=
   ZOOM_IV_FOR_PASS: cGxhY2Vob2xkZXJfdmFsdWU=
-  ZOOM_CLIENT_SECRET: cGxhY2Vob2xkZXJfdmFsdWU=
   ZOOM_WEBHOOK_SECRET_TOKEN: cGxhY2Vob2xkZXJfdmFsdWU=
-  NEXT_PUBLIC_ZOOM_CLIENT_ID: cGxhY2Vob2xkZXJfdmFsdWU=
-  OPTAPLANNER_USERNAME: cGxhY2Vob2xkZXJfdmFsdWU=
-  OPTAPLANNER_PASSWORD: cGxhY2Vob2xkZXJfdmFsdWU= # Often same as API_TOKEN
+  # NEXT_PUBLIC_ZOOM_CLIENT_ID is typically for frontend, if functions backend needs it, it's here from compose.
+
+  # Optaplanner Credentials (if functions service acts as a client to Optaplanner)
+  OPTAPLANNER_USERNAME: cGxhY2Vob2xkZXJfdmFsdWU= # Usually matches API_TOKEN or a specific user
+  OPTAPLANNER_PASSWORD: cGxhY2Vob2xkZXJfdmFsdWU= # Usually matches API_TOKEN
+
+  # SMTP / Email
   SMTP_HOST: cGxhY2Vob2xkZXJfdmFsdWU=
   SMTP_PORT: NTg3 # "587"
   SMTP_USER: cGxhY2Vob2xkZXJfdmFsdWU=
   SMTP_PASS: cGxhY2Vob2xkZXJfdmFsdWU=
   SMTP_FROM_EMAIL: bm9yZXBseUBleGFtcGxlLmNvbQ== # "noreply@example.com"
+
+  # Twilio
   TWILIO_ACCOUNT_SID: cGxhY2Vob2xkZXJfdmFsdWU=
   TWILIO_AUTH_TOKEN: cGxhY2Vob2xkZXJfdmFsdWU=
   TWILIO_PHONE_NO: cGxhY2Vob2xkZXJfdmFsdWU=
-  STRIPE_API_KEY: cGxhY2Vob2xkZXJfdmFsdWU=
+
+  # Stripe
+  STRIPE_API_KEY: cGxhY2Vob2xkZXJfdmFsdWU= # Stripe Secret Key
   STRIPE_WEBHOOK_SECRET: cGxhY2Vob2xkZXJfdmFsdWU=
+
+  # Other External Services / Misc
   ONESIGNAL_APP_ID: cGxhY2Vob2xkZXJfdmFsdWU=
   ONESIGNAL_REST_API_KEY: cGxhY2Vob2xkZXJfdmFsdWU=
   SLACK_BOT_TOKEN: cGxhY2Vob2xkZXJfdmFsdWU=
   SLACK_SIGNING_SECRET: cGxhY2Vob2xkZXJfdmFsdWU=
   SLACK_CHANNEL_ID: cGxhY2Vob2xkZXJfdmFsdWU=
+
   JWT_SECRET: VGhpcyBpcyBhIHZlcnkgc2VjdXJlIGFuZCBsb25nIEpXVCBzZWNyZXQga2V5 # "This is a very secure and long JWT secret key"
   ENCRYPTION_KEY: VGhpcyBpcyBhIHZlcnkgc2VjdXJlIGFuZCBsb25nIGVuY3J5cHRpb24ga2V5 # "This is a very secure and long encryption key"
+  SESSION_SECRET_KEY: U3VwZXJMb25nQW5kU2VjdXJlU2Vzc2lvblNlY3JldEtleUZvckZ1bmN0aW9ucw== # "SuperLongAndSecureSessionSecretKeyForFunctions"
+
+  # Nhost specific variables from compose, if needed by functions directly.
+  # These often alias to Hasura secrets already defined (e.g. NHOST_ADMIN_SECRET -> HASURA_GRAPHQL_ADMIN_SECRET)
+  # NHOST_ADMIN_SECRET: bXlhZG1pbnNlY3JldGtleQ== # Redundant if HASURA_GRAPHQL_ADMIN_SECRET is used
+  NHOST_WEBHOOK_SECRET: cGxhY2Vob2xkZXJfdmFsdWU= # If distinct from other webhook secrets
+  # NHOST_JWT_SECRET: was in compose, relates to Hasura's JWT secret.
+
+  # Ensure all sensitive values from the functions service's environment in docker-compose.yaml are listed here.
+  # Using generic placeholder "cGxhY2Vob2xkZXJfdmFsdWU=" (base64 of "placeholder_value") for unspecified values.

--- a/deploy/kubernetes/base/functions/service.yaml
+++ b/deploy/kubernetes/base/functions/service.yaml
@@ -6,15 +6,15 @@ metadata:
   labels:
     app: functions
 spec:
-  type: ClusterIP
+  type: ClusterIP # Internal service, not exposed externally by default via LoadBalancer
   selector:
     app: functions # Selects the functions pods
   ports:
     - name: main
       protocol: TCP
-      port: 3000 # Port the service will listen on for main traffic
-      targetPort: main # Name of the port in the Deployment's podSpec (containerPort 3000)
+      port: 3000       # Port the service will listen on for main traffic
+      targetPort: main # Matches the 'main' port name in the Deployment's podSpec (containerPort 3000)
     - name: secondary
       protocol: TCP
-      port: 3030 # Port the service will listen on for secondary traffic
-      targetPort: secondary # Name of the port in the Deployment's podSpec (containerPort 3030)
+      port: 3030       # Port the service will listen on for secondary traffic (e.g., WebSockets)
+      targetPort: secondary # Matches the 'secondary' port name in the Deployment's podSpec (containerPort 3030)

--- a/deploy/kubernetes/base/handshake/configmap.yaml
+++ b/deploy/kubernetes/base/handshake/configmap.yaml
@@ -4,29 +4,28 @@ metadata:
   name: handshake-configmap
   namespace: handshake
 data:
-  # Hasura GraphQL URL
+  # Hasura GraphQL URL (for internal communication from Handshake service's backend if applicable)
   HASURA_GRAPHQL_GRAPHQL_URL: "http://hasura-service.hasura.svc.cluster.local:8080/v1/graphql"
 
-  # Meeting Assist Admin URL (pointing to the 'functions' service)
-  # The exact path "/schedule-assist/" needs to be confirmed based on functions service's actual API routes.
-  MEETING_ASSIST_ADMIN_URL: "http://functions-service.functions.svc.cluster.local:3000/schedule-assist/" # Placeholder path, adjust as needed
+  # Meeting Assist Admin URL (pointing to the 'functions' service with specific path)
+  MEETING_ASSIST_ADMIN_URL: "http://functions-service.functions.svc.cluster.local:3000/schedule-assist/publisherScheduleMeeting/schedule-meeting-to-queue-admin"
 
-  # Public URL for the handshake API itself, potentially exposed via an Ingress
-  # This is often used by frontend clients. The ${HOST_NAME} would be replaced by actual domain.
-  # The path "/v1/functions/handshake-api/" suggests it might be a specific route on an API gateway or the functions service itself.
-  # If this handshake service *is* the API, then it would be its own external URL.
-  # Given it's a Next.js app, it might serve its own API routes.
-  # Let's assume this handshake service exposes an API at its root or a specific path.
-  # If NEXT_PUBLIC_ATOMIC_HANDSHAKE_API refers to *this* service's external URL:
-  NEXT_PUBLIC_ATOMIC_HANDSHAKE_API: "https://${HOST_NAME}/api/handshake" # Example path on this service, adjust if needed
+  # Public URL for the handshake API itself, potentially exposed via an Ingress.
+  # This is used by frontend clients. The ${HOST_NAME} would be replaced by actual domain.
+  # The path "/v1/functions/handshake-api/..." suggests it might be a specific route on an API gateway or the functions service.
+  # However, the variable name NEXT_PUBLIC_ATOMIC_HANDSHAKE_API implies it's an API provided BY this handshake service itself.
+  # If this Handshake service (Next.js app) exposes its own API routes at this path:
+  NEXT_PUBLIC_ATOMIC_HANDSHAKE_API: "https://${HOST_NAME}/v1/functions/handshake-api/createRecurMeetAssists/create-recur-meet-assists-public"
 
-  # Default port for Next.js standalone server.js
+  # Default port for this Next.js Handshake application
   PORT: "3000"
 
   # Node environment
   NODE_ENV: "production"
 
-  # Any other non-sensitive environment variables required by the handshake service
-  # For example, if it needs to know its own public URL for generating links (can be same as NEXT_PUBLIC_ATOMIC_HANDSHAKE_API or different)
-  # APP_URL: "https://${HOST_NAME}" # General application URL
-  LOG_LEVEL: "info"
+  # Logging level (optional, can be added if needed)
+  # LOG_LEVEL: "info"
+
+  # Placeholder for the external host name. This variable itself isn't typically used directly by Next.js like this,
+  # but the value would be substituted into the URLs above during deployment or by an Ingress controller.
+  HOST_NAME: "your-app-domain.com" # Example placeholder, actual value depends on deployment context.

--- a/deploy/kubernetes/base/handshake/deployment.yaml
+++ b/deploy/kubernetes/base/handshake/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: handshake
 spec:
-  replicas: 1 # Can be scaled as Next.js standalone apps are typically stateless
+  replicas: 1 # As specified, can be scaled
   selector:
     matchLabels:
       app: handshake
@@ -17,20 +17,19 @@ spec:
     spec:
       containers:
         - name: handshake
-          image: "${PROJECT_NAME}-atomic-handshake:latest" # Placeholder - replace with actual image URL
-          imagePullPolicy: IfNotPresent # Or Always if using 'latest' tag frequently
+          image: "placeholder-atomic-handshake:latest" # Consistent placeholder name
+          imagePullPolicy: IfNotPresent
           ports:
             - name: http
-              containerPort: 3000 # Matches PORT in ConfigMap
+              containerPort: 3000 # Should match PORT in ConfigMap
               protocol: TCP
           envFrom:
             - secretRef:
                 name: handshake-secret
             - configMapRef:
                 name: handshake-configmap
-          # Ensure the application uses the PORT environment variable from the ConfigMap
-          # if it's not defaulting to 3000 via its Dockerfile's EXPOSE or CMD.
-          # The Next.js standalone server typically listens on the port specified by the PORT env var.
+          # The application should use the PORT environment variable from the ConfigMap.
+          # Next.js standalone server typically listens on the port specified by the PORT env var.
 
           # Probes: Next.js apps in standalone mode usually serve on '/'.
           # If a specific health check endpoint is available (e.g., /api/health), use that.

--- a/deploy/kubernetes/base/handshake/kustomization.yaml
+++ b/deploy/kubernetes/base/handshake/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: handshake
+namespace: handshake # Sets the namespace for all resources in this kustomization
 
 resources:
   - namespace.yaml
@@ -10,11 +10,13 @@ resources:
   - deployment.yaml
   - service.yaml
 
-# Optional: Add common labels to all resources
+# Optional: Add common labels to all resources defined in this kustomization
 # commonLabels:
 #   app.kubernetes.io/name: handshake
+#   app.kubernetes.io/instance: handshake
+#   app.kubernetes.io/component: frontend-api # Or as appropriate
 #   app.kubernetes.io/part-of: atomic-stack
 
 # Optional: Add common annotations
 # commonAnnotations:
-#   source: "https://github.com/your-repo/atomic-stack"
+#   note: "Handshake service base configuration"

--- a/deploy/kubernetes/base/handshake/secret.yaml
+++ b/deploy/kubernetes/base/handshake/secret.yaml
@@ -5,8 +5,9 @@ metadata:
   namespace: handshake
 type: Opaque
 data:
-  # API_TOKEN for authenticating with other backend services if needed
+  # API_TOKEN for authenticating with other backend services if needed by Handshake service
   API_TOKEN: aGFuZHNoYWtlX2FwaV90b2tlbl9wbGFjZWhvbGRlcg== # "handshake_api_token_placeholder"
 
-  # HASURA_GRAPHQL_ADMIN_SECRET for privileged operations against Hasura, if needed directly
+  # HASURA_GRAPHQL_ADMIN_SECRET for privileged operations against Hasura, if Handshake service needs it directly.
+  # This was identified as a Dockerfile ARG for this service.
   HASURA_GRAPHQL_ADMIN_SECRET: bXlhZG1pbnNlY3JldGtleQ== # "myadminsecretkey" (ensure this matches Hasura's actual admin secret)

--- a/deploy/kubernetes/base/handshake/service.yaml
+++ b/deploy/kubernetes/base/handshake/service.yaml
@@ -6,11 +6,11 @@ metadata:
   labels:
     app: handshake
 spec:
-  type: ClusterIP
+  type: ClusterIP # Internal service
   selector:
     app: handshake # Selects the handshake pods
   ports:
     - name: http
       protocol: TCP
-      port: 3000 # Port the service will listen on
-      targetPort: http # Name of the port in the Deployment's podSpec (containerPort 3000)
+      port: 3000       # Port the service will listen on
+      targetPort: http # Matches the 'http' port name in the Deployment's podSpec (containerPort 3000)

--- a/deploy/kubernetes/base/hasura/deployment.yaml
+++ b/deploy/kubernetes/base/hasura/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: hasura-graphql-engine
 spec:
-  replicas: 1
+  replicas: 1 # As specified, Hasura is stateless and can be scaled
   selector:
     matchLabels:
       app: hasura-graphql-engine
@@ -17,19 +17,19 @@ spec:
     spec:
       containers:
         - name: hasura
-          image: hasura/graphql-engine:v2.15.2
+          image: hasura/graphql-engine:v2.15.2 # As specified
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
-              containerPort: 8080
+              containerPort: 8080 # Default Hasura port
               protocol: TCP
           env:
-            # Construct HASURA_GRAPHQL_DATABASE_URL from secret values
-            # This requires the container's entrypoint or command to handle variable substitution.
-            # Hasura's docker image entrypoint does this.
+            # Construct HASURA_GRAPHQL_DATABASE_URL from individual secret values.
+            # Hasura's entrypoint script handles this variable substitution.
             - name: HASURA_GRAPHQL_DATABASE_URL
               value: "postgres://$(DB_USER):$(DB_PASSWORD)@$(DB_HOST):$(DB_PORT)/$(DB_NAME)"
-            # Source individual DB components for the above URI construction
+
+            # Source individual DB components from the secret for the URI construction above
             - name: DB_USER
               valueFrom:
                 secretKeyRef:
@@ -68,7 +68,7 @@ spec:
                   name: hasura-secret
                   key: HASURA_GRAPHQL_ADMIN_SECRET
 
-            # Other Hasura configurations from compose
+            # Other Hasura configurations from the prompt
             - name: HASURA_GRAPHQL_UNAUTHORIZED_ROLE
               value: "public"
             - name: HASURA_GRAPHQL_LOG_LEVEL
@@ -79,16 +79,16 @@ spec:
           readinessProbe:
             httpGet:
               path: /healthz # Hasura's health check endpoint
-              port: http # 8080
-            initialDelaySeconds: 5
+              port: http   # Port 8080
+            initialDelaySeconds: 10 # Allow time for Hasura to connect to DB and start
             periodSeconds: 10
-            timeoutSeconds: 2
+            timeoutSeconds: 5
             failureThreshold: 3
           livenessProbe:
             httpGet:
               path: /healthz
               port: http
-            initialDelaySeconds: 15
-            periodSeconds: 20
-            timeoutSeconds: 2
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            timeoutSeconds: 5
             failureThreshold: 3

--- a/deploy/kubernetes/base/hasura/kustomization.yaml
+++ b/deploy/kubernetes/base/hasura/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: hasura
+namespace: hasura # Sets the namespace for all resources in this kustomization
 
 resources:
   - namespace.yaml
@@ -9,11 +9,13 @@ resources:
   - deployment.yaml
   - service.yaml
 
-# Optional: Add common labels to all resources
+# Optional: Add common labels to all resources defined in this kustomization
 # commonLabels:
-#   app.kubernetes.io/name: hasura-graphql-engine
-#   app.kubernetes.io/part-of: atomic-stack
+#   app.kubernetes.io/name: hasura
+#   app.kubernetes.io/instance: hasura-graphql-engine
+#   app.kubernetes.io/component: graphql-engine
+#   app.kubernetes.io/part-of: atomic-stack # Or your specific application/project name
 
 # Optional: Add common annotations
 # commonAnnotations:
-#   source: "https://github.com/your-repo/atomic-stack"
+#   note: "Hasura GraphQL Engine base configuration"

--- a/deploy/kubernetes/base/hasura/secret.yaml
+++ b/deploy/kubernetes/base/hasura/secret.yaml
@@ -7,14 +7,11 @@ type: Opaque
 data:
   # Hasura specific secrets
   HASURA_GRAPHQL_ADMIN_SECRET: bXlhZG1pbnNlY3JldGtleQ== # "myadminsecretkey"
-  HASURA_GRAPHQL_JWT_SECRET: eyJ0eXBlIjoiSFMyNTYiLCJrZXkiOiJ0aGlzLWlzLWEtdmVyeS1sb25nLWFuZC1zZWN1cmUtc2VjcmV0LWtleS1mb3ItaHMyNTYiLCJjbGFpbXNfbmFtZXNwYWNlIjoiaGFzdXJhLXVzZXItY2xhaW1zIn0= # {"type":"HS256","key":"this-is-a-very-long-and-secure-secret-key-for-hs256","claims_namespace":"hasura-user-claims"}
+  HASURA_GRAPHQL_JWT_SECRET: eyJ0eXBlIjoiSFMyNTYiLCJrZXkiOiJ0aGlzLWlzLWEtdmVyeS1sb25nLWFuZC1zZWN1cmUtc2VjcmV0LWtleS1mb3ItaHMyNTYtaGFzdXJhLWp3dCIsImNsYWltc19uYW1lc3BhY2UiOiJoYXN1cmEtdXNlci1jbGFpbXMifQ== # {"type":"HS256","key":"this-is-a-very-long-and-secure-secret-key-for-hs256-hasura-jwt","claims_namespace":"hasura-user-claims"}
 
   # PostgreSQL connection components
   DB_USER: cG9zdGdyZXM= # "postgres"
   DB_PASSWORD: c2VjcmV0cGdwYXNzd29yZA== # "secretpgpassword"
-  # DB_HOST should be the address of the PostgreSQL service.
-  # Assuming PostgreSQL is in 'postgres' namespace with service 'postgres-service':
-  # postgres-service.postgres.svc.cluster.local
-  DB_HOST: cG9zdGdyZXMtc2VydmljZS5wb3N0Z3Jlcy5zdmMuY2x1c3Rlci5sb2NhbA==
+  DB_HOST: cG9zdGdyZXMtc2VydmljZS5wb3N0Z3Jlcy5zdmMuY2x1c3Rlci5sb2NhbA== # "postgres-service.postgres.svc.cluster.local"
   DB_PORT: NTQzMg== # "5432"
   DB_NAME: YXRvbWljZGI= # "atomicdb"

--- a/deploy/kubernetes/base/hasura/service.yaml
+++ b/deploy/kubernetes/base/hasura/service.yaml
@@ -6,11 +6,11 @@ metadata:
   labels:
     app: hasura-graphql-engine
 spec:
-  type: ClusterIP
+  type: ClusterIP # Internal service, not exposed externally by default
   selector:
     app: hasura-graphql-engine # Selects the Hasura pods
   ports:
     - name: http
       protocol: TCP
-      port: 8080 # Port the service will listen on
-      targetPort: http # Name of the port in the Deployment's podSpec (containerPort 8080)
+      port: 8080       # Port the service will listen on
+      targetPort: http # Matches the 'http' port name in the Deployment's podSpec (containerPort 8080)

--- a/deploy/kubernetes/base/kafka/kafka-service.yaml
+++ b/deploy/kubernetes/base/kafka/kafka-service.yaml
@@ -1,4 +1,4 @@
-# Headless service for Kafka broker pod discovery (DNS records for kafka-0.kafka-headless.kafka.svc.cluster.local)
+# Headless service for Kafka broker pod discovery (DNS records like kafka-0.kafka-headless.kafka.svc.cluster.local)
 apiVersion: v1
 kind: Service
 metadata:
@@ -9,15 +9,14 @@ metadata:
 spec:
   clusterIP: None # Defines the service as headless
   selector:
-    app: kafka
+    app: kafka # Selects the Kafka pods
   ports:
     - name: internal # Port for broker-to-broker or direct pod access if needed
       port: 9092
-      targetPort: internal
-    # Add other ports if necessary, e.g., for different listener types
+      targetPort: internal # Matches 'internal' port name in Kafka StatefulSet
 
 ---
-# ClusterIP service for Kafka clients (applications connecting to Kafka)
+# ClusterIP service for Kafka clients (applications connecting to Kafka broker)
 apiVersion: v1
 kind: Service
 metadata:
@@ -30,7 +29,7 @@ spec:
   selector:
     app: kafka # Selects the Kafka pods
   ports:
-    - name: client
+    - name: client # Port for clients to connect to Kafka
       protocol: TCP
-      port: 9092 # External port clients connect to
-      targetPort: internal # Target port on the Kafka pods (containerPort name 'internal')
+      port: 9092       # External port clients connect to (service port)
+      targetPort: internal # Target port on the Kafka pods (containerPort name 'internal', which is 9092)

--- a/deploy/kubernetes/base/kafka/kafka-statefulset.yaml
+++ b/deploy/kubernetes/base/kafka/kafka-statefulset.yaml
@@ -7,7 +7,7 @@ metadata:
     app: kafka
 spec:
   serviceName: "kafka-headless" # Must match the headless Service name
-  replicas: 1
+  replicas: 1 # For base simplicity
   selector:
     matchLabels:
       app: kafka
@@ -16,71 +16,63 @@ spec:
       labels:
         app: kafka
     spec:
-      terminationGracePeriodSeconds: 30 # Kafka can take longer to shutdown cleanly
+      terminationGracePeriodSeconds: 30 # Kafka can take time to shut down cleanly
       containers:
         - name: kafka
-          image: confluentinc/cp-kafka:5.4.2
+          image: confluentinc/cp-kafka:5.4.2 # As specified
           imagePullPolicy: IfNotPresent
           ports:
-            - name: internal
-              containerPort: 9092 # Port for internal cluster communication and default client access
+            - name: internal # PLAINTEXT port for internal communication and clients
+              containerPort: 9092
               protocol: TCP
-            # Port 29092 was mentioned for external, but for ClusterIP, 9092 is primary.
-            # If NodePort or LoadBalancer were used, 29092 might be configured for external access.
           env:
             - name: KAFKA_BROKER_ID
-              value: "0" # For a single broker setup, ID 0 is typical
+              value: "0" # For a single broker, ID 0 is typical
             - name: KAFKA_ZOOKEEPER_CONNECT
-              # Assumes zookeeper-service is resolvable in the same namespace.
-              # For cross-namespace, use FQDN: zookeeper-service.kafka.svc.cluster.local:2181
-              value: "zookeeper-service:2181"
-            # Listeners: PLAINTEXT within the cluster.
-            # The advertised listener needs to be the address clients use.
-            # For in-cluster access via the headless service FQDN for the pod:
-            - name: KAFKA_LISTENERS
+              value: "zookeeper-service.kafka.svc.cluster.local:2181" # FQDN for Zookeeper service
+            - name: KAFKA_LISTENERS # Listener within the pod network
               value: "PLAINTEXT://:9092"
-            - name: KAFKA_ADVERTISED_LISTENERS
-              # kafka-0 is the pod name, kafka-headless is the service name, kafka is the namespace
+            - name: KAFKA_ADVERTISED_LISTENERS # How clients connect to this specific broker
+                                              # Uses the pod's FQDN: kafka-0.kafka-headless.kafka.svc.cluster.local
               value: "PLAINTEXT://kafka-0.kafka-headless.kafka.svc.cluster.local:9092"
             - name: KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR
-              value: "1" # For single broker cluster
+              value: "1" # For a single broker cluster
             - name: KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS
               value: "0"
             - name: KAFKA_LOG_DIRS # Directory where Kafka data logs are stored
-              value: "/var/lib/kafka/data/logs" # Standard location within the volume
-            # Additional recommended settings for single node / dev:
-            - name: KAFKA_DEFAULT_REPLICATION_FACTOR
+              value: "/var/lib/kafka/data/logs" # Standard location within the mounted volume
+            - name: KAFKA_DEFAULT_REPLICATION_FACTOR # For auto-created topics
               value: "1"
-            - name: KAFKA_NUM_PARTITIONS
-              value: "1" # Default for auto-created topics
-            # Control plane listener (new in some Kafka versions, good practice for Confluent)
-            # - name: KAFKA_CONTROL_PLANE_LISTENER_NAME
-            #   value: "CONTROL_PLANE"
-            # - name: KAFKA_LISTENER_SECURITY_PROTOCOL_MAP
-            #   value: "PLAINTEXT:PLAINTEXT,CONTROL_PLANE:PLAINTEXT"
-            # - name: KAFKA_LISTENERS
-            #   value: "PLAINTEXT://:9092,CONTROL_PLANE://:9091" # Example if control plane listener is used
-
+            - name: KAFKA_NUM_PARTITIONS # Default partitions for auto-created topics
+              value: "1"
+            # Confluent specific variables for control center, etc. (can be omitted for base)
+            # KAFKA_CONFLUENT_LICENSE_TOPIC_REPLICATION_FACTOR: "1"
+            # KAFKA_CONFLUENT_BALANCER_TOPIC_REPLICATION_FACTOR: "1"
+            # KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: "1"
+            # KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: "1"
           volumeMounts:
-            - name: kafka-data
+            - name: kafka-data # Corresponds to volumeClaimTemplates.metadata.name
               mountPath: /var/lib/kafka/data
           readinessProbe:
             tcpSocket:
-              port: 9092
+              port: internal # Port 9092
             initialDelaySeconds: 15
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 3
-          # Liveness probe can be tricky for Kafka, often omitted or made less aggressive.
-          # A simple TCP check can indicate if the broker process is up.
           livenessProbe:
             tcpSocket:
-              port: 9092
-            initialDelaySeconds: 60
+              port: internal
+            initialDelaySeconds: 60 # Give more time for Kafka to start before liveness checks
             periodSeconds: 30
             timeoutSeconds: 5
             failureThreshold: 3
-      volumes:
-        - name: kafka-data
-          persistentVolumeClaim:
-            claimName: kafka-data-pvc
+  volumeClaimTemplates:
+  - metadata:
+      name: kafka-data # Name for the data PVC template
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 10Gi # As specified
+      # storageClassName: "your-storage-class" # Optional

--- a/deploy/kubernetes/base/kafka/kustomization.yaml
+++ b/deploy/kubernetes/base/kafka/kustomization.yaml
@@ -1,21 +1,23 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: kafka
+namespace: kafka # Sets the namespace for all resources in this kustomization
 
 resources:
   - namespace.yaml
-  - zookeeper-pvc.yaml
+  # PVCs are now part of statefulset volumeClaimTemplates, so no separate PVC files.
+  # - zookeeper-pvc.yaml # Removed
+  # - kafka-pvc.yaml # Removed
   - zookeeper-statefulset.yaml
   - zookeeper-service.yaml
-  - kafka-pvc.yaml
   - kafka-statefulset.yaml
   - kafka-service.yaml
 
-# Optional: Add common labels to all resources
+# Optional: Add common labels to all resources defined in this kustomization
 # commonLabels:
-#   app.kubernetes.io/part-of: atomic-stack
+#   app.kubernetes.io/component: message-queue
+#   app.kubernetes.io/part-of: atomic-stack # Or your specific application/project name
 
 # Optional: Add common annotations
 # commonAnnotations:
-#   source: "https://github.com/your-repo/atomic-stack"
+#   note: "Kafka and Zookeeper base configuration"

--- a/deploy/kubernetes/base/kafka/zookeeper-service.yaml
+++ b/deploy/kubernetes/base/kafka/zookeeper-service.yaml
@@ -1,4 +1,4 @@
-# Headless service for Zookeeper pod discovery (DNS records for zookeeper-0.zookeeper-headless.kafka.svc.cluster.local)
+# Headless service for Zookeeper pod discovery (DNS records like zookeeper-0.zookeeper-headless.kafka.svc.cluster.local)
 apiVersion: v1
 kind: Service
 metadata:
@@ -9,8 +9,11 @@ metadata:
 spec:
   clusterIP: None # Defines the service as headless
   selector:
-    app: zookeeper
+    app: zookeeper # Selects the Zookeeper pods
   ports:
+    - name: client # Port 2181 is also exposed here for completeness, though client-service is primary for clients
+      port: 2181
+      targetPort: client
     - name: server
       port: 2888
       targetPort: server
@@ -19,7 +22,7 @@ spec:
       targetPort: leader-election
 
 ---
-# ClusterIP service for Zookeeper clients
+# ClusterIP service for Zookeeper clients (e.g., Kafka brokers)
 apiVersion: v1
 kind: Service
 metadata:
@@ -30,9 +33,9 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    app: zookeeper
+    app: zookeeper # Selects the Zookeeper pods
   ports:
     - name: client
       protocol: TCP
-      port: 2181
-      targetPort: client
+      port: 2181       # Port the service will listen on for client connections
+      targetPort: client # Matches the 'client' port name in the Zookeeper StatefulSet (containerPort 2181)

--- a/deploy/kubernetes/base/kafka/zookeeper-statefulset.yaml
+++ b/deploy/kubernetes/base/kafka/zookeeper-statefulset.yaml
@@ -7,7 +7,7 @@ metadata:
     app: zookeeper
 spec:
   serviceName: "zookeeper-headless" # Must match the headless Service name
-  replicas: 1
+  replicas: 1 # For base simplicity
   selector:
     matchLabels:
       app: zookeeper
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
         - name: zookeeper
-          image: confluentinc/cp-zookeeper:5.4.2
+          image: confluentinc/cp-zookeeper:5.4.2 # As specified
           imagePullPolicy: IfNotPresent
           ports:
             - name: client
@@ -36,22 +36,21 @@ spec:
               value: "2181"
             - name: ZOOKEEPER_TICK_TIME
               value: "2000"
-            - name: ZOOKEEPER_DATA_DIR
+            - name: ZOOKEEPER_DATA_DIR # Path for data
               value: "/var/lib/zookeeper/data"
-            - name: ZOOKEEPER_LOG_DIR # Note: confluent images might use ZOOKEEPER_DATA_LOG_DIR or just log to data dir by default.
-              value: "/var/lib/zookeeper/log" # Explicitly setting log dir.
-            # For single node, server ID is typically 1
-            - name: ZOOKEEPER_SERVER_ID
+            - name: ZOOKEEPER_LOG_DIR # Path for logs (or ZOOKEEPER_DATA_LOG_DIR for some older Confluent images)
+              value: "/var/lib/zookeeper/log"
+            - name: ZOOKEEPER_SERVER_ID # For single node, typically 1
               value: "1"
-            # For single node, servers list is just itself
+            # For single node, ZOOKEEPER_SERVERS can be omitted or point to itself.
+            # Confluent images often expect this for proper initialization, even for a single instance.
+            # The FQDN format is pod-name.service-name.namespace.svc.cluster.local
             - name: ZOOKEEPER_SERVERS
               value: "zookeeper-0.zookeeper-headless.kafka.svc.cluster.local:2888:3888"
-
-
           volumeMounts:
-            - name: zookeeper-data
+            - name: data # Corresponds to volumeClaimTemplates.metadata.name for data
               mountPath: /var/lib/zookeeper/data
-            - name: zookeeper-log
+            - name: log  # Corresponds to volumeClaimTemplates.metadata.name for logs
               mountPath: /var/lib/zookeeper/log
           readinessProbe:
             exec:
@@ -73,10 +72,20 @@ spec:
             periodSeconds: 15
             timeoutSeconds: 5
             failureThreshold: 3
-      volumes:
-        - name: zookeeper-data
-          persistentVolumeClaim:
-            claimName: zookeeper-data-pvc
-        - name: zookeeper-log
-          persistentVolumeClaim:
-            claimName: zookeeper-log-pvc
+  volumeClaimTemplates:
+  - metadata:
+      name: data # Name for the data PVC template
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 5Gi # As specified
+      # storageClassName: "your-storage-class" # Optional
+  - metadata:
+      name: log # Name for the log PVC template
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 5Gi # As specified
+      # storageClassName: "your-storage-class" # Optional

--- a/deploy/kubernetes/base/kustomization.yaml
+++ b/deploy/kubernetes/base/kustomization.yaml
@@ -1,24 +1,29 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-# This root kustomization file includes all the base services.
-# Each service subdirectory has its own kustomization.yaml,
-# defining resources and typically its own namespace.
+# This is the root Kustomization file for the 'base' Kubernetes manifests.
+# It aggregates all the individual service components, each defined in its own subdirectory
+# and managed by its own kustomization.yaml file.
+# Applying this kustomization (e.g., `kubectl apply -k deploy/kubernetes/base/`)
+# will deploy all the base services into the cluster, each typically in its own namespace.
 
 resources:
+  # Ingress Controller
+  - ./traefik
+
   # Data Stores & Message Queues
-  - ./postgres
   - ./minio
+  - ./postgres
   - ./kafka # Includes Zookeeper and Kafka Broker
   - ./opensearch
 
   # Authentication & Authorization
   - ./supertokens
-  - ./oauth # Handles OAuth flows
+  - ./oauth # Handles OAuth flows for other services
 
   # Backend Services / Core Logic
   - ./hasura # GraphQL Engine
-  - ./functions # Serverless functions / Microservices
+  - ./functions # Serverless functions / Microservices / Backend logic
   - ./optaplanner # Scheduling service
 
   # Frontend / Edge Services
@@ -26,21 +31,20 @@ resources:
   - ./handshake # Handshake Next.js application
 
 # Common labels and annotations can be defined here to apply to all resources
-# across all included kustomizations if desired, but it's often cleaner
-# to manage them within each component's kustomization or via overlays.
+# across all included kustomizations if desired. However, it's often cleaner
+# to manage them within each component's kustomization or via overlays,
+# especially since each component here has its own namespace.
 #
+# Example (if you wanted to apply these to ALL resources from ALL sub-kustomizations):
 # commonLabels:
 #   environment: base
-#   project: atomic-stack
+#   project: atomic-stack # Replace with your actual project identifier
 #
 # commonAnnotations:
 #   managed-by: kustomize
+#   owner: platform-team
 
-# Note: If a 'traefik' directory with its own kustomization.yaml exists
-# or is added later, it should be added to the resources list here:
-# - ./traefik
-
-# Similarly, if a common namespace is desired for all these base resources
-# (instead of each service having its own), it could be specified here.
-# However, the current setup gives each service its own namespace for modularity.
-# namespace: default-stack # Example if a common namespace was used.
+# Note: The order of resources listed here generally does not affect deployment order
+# for Kustomize, as dependencies are typically managed by Kubernetes itself or
+# through explicit 'dependsOn' annotations if needed for specific CRD readiness, etc.
+# However, grouping them logically (e.g., by type or dependency) can improve readability.

--- a/deploy/kubernetes/base/oauth/configmap.yaml
+++ b/deploy/kubernetes/base/oauth/configmap.yaml
@@ -4,40 +4,35 @@ metadata:
   name: oauth-configmap
   namespace: oauth
 data:
-  # General Application URLs
-  # NEXT_PUBLIC_APP_URL: This is the main frontend application URL that users access.
-  # It's where users might be redirected back to after successful OAuth flows.
-  NEXT_PUBLIC_APP_URL: "https://${HOST_NAME}" # Placeholder, replace ${HOST_NAME} with actual external domain
+  # External Application URL (where users are redirected back to)
+  NEXT_PUBLIC_APP_URL: "https://${HOST_NAME}"
 
-  # Handshake Service URL (internal Kubernetes service)
+  # Google OAuth Redirect URL (Callback URL for this oauth service)
+  GOOGLE_REDIRECT_URL: "https://${HOST_NAME}/v1/oauth/api/google-calendar-handshake/oauth2callback"
+
+  # Handshake Service URL (Internal Kubernetes service FQDN)
   HANDSHAKE_URL: "http://handshake-service.handshake.svc.cluster.local:3000"
 
-  # Google OAuth Configuration
-  # GOOGLE_REDIRECT_URL: The callback URL registered with Google for this OAuth service.
-  # It must point to an endpoint on this 'oauth' service itself, externally accessible.
-  GOOGLE_REDIRECT_URL: "https://${HOST_NAME}/v1/oauth/api/google-calendar-handshake/oauth2callback" # Path needs to match actual API route
+  # Zoom OAuth Redirect URL (Callback URL for this oauth service)
+  NEXT_PUBLIC_ZOOM_REDIRECT_URL: "https://${HOST_NAME}/v1/oauth/zoom/mobile-callback"
 
-  # Zoom OAuth Configuration
-  # NEXT_PUBLIC_ZOOM_CLIENT_ID: This is often the same as ZOOM_CLIENT_ID from secrets.
-  # If it's explicitly public and different, define it here. Otherwise, it can be sourced from secrets.
-  # For now, let's assume it's needed publicly and might be same or different.
-  # If it's always same as secret ZOOM_CLIENT_ID, app can just use that.
-  # If it's for frontend use and ZOOM_CLIENT_ID in secret is for backend, it could be different.
-  # Let's provide a placeholder here.
-  NEXT_PUBLIC_ZOOM_CLIENT_ID: "YOUR_PUBLIC_ZOOM_CLIENT_ID_IF_DIFFERENT" # Or reference from secret if same and app handles it
+  # Public Zoom Client ID (can be same as ZOOM_CLIENT_ID from secret, or a different public one)
+  # If it's always the same as the secret one, the app could just use the env var from the secret.
+  # Including it here if it's meant to be distinctly configured or explicitly public.
+  NEXT_PUBLIC_ZOOM_CLIENT_ID: "YOUR_PUBLIC_ZOOM_CLIENT_ID_PLACEHOLDER"
 
-  # NEXT_PUBLIC_ZOOM_REDIRECT_URL: The callback URL registered with Zoom for this OAuth service.
-  # It must point to an endpoint on this 'oauth' service itself, externally accessible.
-  NEXT_PUBLIC_ZOOM_REDIRECT_URL: "https://${HOST_NAME}/v1/oauth/zoom/mobile-callback" # Path needs to match actual API route
+  # Hasura GraphQL URL (if this oauth service needs to query Hasura for non-admin tasks)
+  HASURA_GRAPHQL_GRAPHQL_URL: "http://hasura-service.hasura.svc.cluster.local:8080/v1/graphql"
 
-  # Default port for this Next.js OAuth service
+  # Application Port for this Next.js OAuth service
   PORT: "3000"
 
-  # Node environment
+  # Node Environment
   NODE_ENV: "production"
 
-  # Logging level
-  LOG_LEVEL: "info"
+  # Logging Level (optional)
+  # LOG_LEVEL: "info"
 
-  # Hasura URL (if the oauth service needs to query Hasura for non-admin tasks)
-  HASURA_GRAPHQL_GRAPHQL_URL: "http://hasura-service.hasura.svc.cluster.local:8080/v1/graphql"
+  # Placeholder for the external host name.
+  # This value would be substituted into the URLs above by deployment automation or Ingress controller.
+  HOST_NAME: "your-app-domain.com" # Example placeholder

--- a/deploy/kubernetes/base/oauth/deployment.yaml
+++ b/deploy/kubernetes/base/oauth/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: oauth
 spec:
-  replicas: 1 # Can be scaled as Next.js standalone apps are typically stateless
+  replicas: 1 # As specified, can be scaled if stateless
   selector:
     matchLabels:
       app: oauth
@@ -17,18 +17,19 @@ spec:
     spec:
       containers:
         - name: oauth
-          image: "${PROJECT_NAME}-atomic-oauth:latest" # Placeholder - replace with actual image URL
+          image: "placeholder-atomic-oauth:latest" # Consistent placeholder name
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
-              containerPort: 3000 # Matches PORT in ConfigMap
+              containerPort: 3000 # Should match PORT in ConfigMap
               protocol: TCP
           envFrom:
             - secretRef:
                 name: oauth-secret
             - configMapRef:
                 name: oauth-configmap
-          # The Next.js standalone server typically listens on the port specified by the PORT env var from the ConfigMap.
+          # The application should use the PORT environment variable from the ConfigMap.
+          # Next.js standalone server typically listens on the port specified by the PORT env var.
 
           # Probes: Next.js apps in standalone mode usually serve on '/'.
           # If a specific health check endpoint is available (e.g., /api/health), use that.

--- a/deploy/kubernetes/base/oauth/kustomization.yaml
+++ b/deploy/kubernetes/base/oauth/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: oauth
+namespace: oauth # Sets the namespace for all resources in this kustomization
 
 resources:
   - namespace.yaml
@@ -10,11 +10,13 @@ resources:
   - deployment.yaml
   - service.yaml
 
-# Optional: Add common labels to all resources
+# Optional: Add common labels to all resources defined in this kustomization
 # commonLabels:
 #   app.kubernetes.io/name: oauth
+#   app.kubernetes.io/instance: oauth
+#   app.kubernetes.io/component: authentication-provider # Or as appropriate
 #   app.kubernetes.io/part-of: atomic-stack
 
 # Optional: Add common annotations
 # commonAnnotations:
-#   source: "https://github.com/your-repo/atomic-stack"
+#   note: "OAuth service base configuration"

--- a/deploy/kubernetes/base/oauth/secret.yaml
+++ b/deploy/kubernetes/base/oauth/secret.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: oauth
 type: Opaque
 data:
-  # Zoom Secrets
+  # Zoom Secrets (as per Dockerfile ARGs)
   ZOOM_CLIENT_ID: cGxhY2Vob2xkZXJfdmFsdWU= # "placeholder_value"
   ZOOM_CLIENT_SECRET: cGxhY2Vob2xkZXJfdmFsdWU=
   ZOOM_IV_FOR_PASS: cGxhY2Vob2xkZXJfdmFsdWU=
@@ -13,13 +13,15 @@ data:
   ZOOM_PASS_KEY: cGxhY2Vob2xkZXJfdmFsdWU=
   ZOOM_WEBHOOK_SECRET_TOKEN: cGxhY2Vob2xkZXJfdmFsdWU=
 
-  # Google Secrets
+  # Google Secrets (as per Dockerfile ARGs)
   GOOGLE_CLIENT_ID_WEB: cGxhY2Vob2xkZXJfdmFsdWU=
   GOOGLE_CLIENT_SECRET_WEB: cGxhY2Vob2xkZXJfdmFsdWU=
 
-  # Hasura Admin Secret (if direct privileged access is needed)
-  HASURA_GRAPHQL_ADMIN_SECRET: bXlhZG1pbnNlY3JldGtleQ== # "myadminsecretkey" (ensure this matches Hasura's actual admin secret)
+  # Hasura Admin Secret (as per Dockerfile ARGs)
+  HASURA_GRAPHQL_ADMIN_SECRET: bXlhZG1pbnNlY3JldGtleQ== # "myadminsecretkey"
 
-  # Any other sensitive variables derived from ARGs or runtime needs
-  # For example, a session secret for the oauth service itself
-  SESSION_SECRET_KEY: MlYzM0JsNVBUbUZuZFdGMFpYTXRZbVZrYzJsd0oyeHNiM2RmWlc1aGJDZ25jbTlzYkdsdw== # "SuperLongAndSecureSessionSecretKeyForOAuthService"
+  # Session Secret for this OAuth service
+  SESSION_SECRET_KEY: U3VwZXJMb25nQW5kU2VjdXJlU2Vzc2lvblNlY3JldEtleUZvck9BdXRoU2VydmljZQ== # "SuperLongAndSecureSessionSecretKeyForOAuthService"
+
+  # Any other sensitive variables identified from ARGs or runtime needs for the oauth service.
+  # Ensure all ARGs from the Dockerfile that are sensitive are listed here.

--- a/deploy/kubernetes/base/oauth/service.yaml
+++ b/deploy/kubernetes/base/oauth/service.yaml
@@ -6,11 +6,11 @@ metadata:
   labels:
     app: oauth
 spec:
-  type: ClusterIP
+  type: ClusterIP # Internal service
   selector:
     app: oauth # Selects the oauth pods
   ports:
     - name: http
       protocol: TCP
-      port: 3000 # Port the service will listen on
-      targetPort: http # Name of the port in the Deployment's podSpec (containerPort 3000)
+      port: 3000       # Port the service will listen on
+      targetPort: http # Matches the 'http' port name in the Deployment's podSpec (containerPort 3000)

--- a/deploy/kubernetes/base/opensearch/kustomization.yaml
+++ b/deploy/kubernetes/base/opensearch/kustomization.yaml
@@ -1,19 +1,21 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: opensearch
+namespace: opensearch # Sets the namespace for all resources in this kustomization
 
 resources:
   - namespace.yaml
-  - pvc.yaml
+  # - pvc.yaml # Removed, as PVC is now defined via volumeClaimTemplates in statefulset.yaml
   - statefulset.yaml
   - service.yaml
 
-# Optional: Add common labels to all resources
+# Optional: Add common labels to all resources defined in this kustomization
 # commonLabels:
 #   app.kubernetes.io/name: opensearch
-#   app.kubernetes.io/part-of: atomic-stack
+#   app.kubernetes.io/instance: opensearch
+#   app.kubernetes.io/component: search-engine
+#   app.kubernetes.io/part-of: atomic-stack # Or your specific application/project name
 
 # Optional: Add common annotations
 # commonAnnotations:
-#   source: "https://github.com/your-repo/atomic-stack"
+#   note: "OpenSearch service base configuration"

--- a/deploy/kubernetes/base/opensearch/service.yaml
+++ b/deploy/kubernetes/base/opensearch/service.yaml
@@ -1,24 +1,4 @@
-# Headless service for OpenSearch pod discovery
-apiVersion: v1
-kind: Service
-metadata:
-  name: opensearch-headless
-  namespace: opensearch
-  labels:
-    app: opensearch
-spec:
-  clusterIP: None # Defines the service as headless
-  selector:
-    app: opensearch
-  ports:
-    # Port 9600 is for node-to-node communication (transport)
-    # It's useful for the headless service if you had multiple nodes.
-    - name: transport
-      port: 9600
-      targetPort: transport
-
----
-# ClusterIP service for OpenSearch clients
+# ClusterIP Service for client connections to OpenSearch (HTTP REST API)
 apiVersion: v1
 kind: Service
 metadata:
@@ -29,13 +9,36 @@ metadata:
 spec:
   type: ClusterIP
   selector:
+    app: opensearch # Selects the OpenSearch pods managed by the StatefulSet
+  ports:
+    - name: http # For REST API
+      protocol: TCP
+      port: 9200       # Port the service will listen on
+      targetPort: http # Matches the 'http' port name in the StatefulSet's podSpec (containerPort 9200)
+    - name: transport # For node-to-node communication (though less relevant for single node, good practice to define)
+      protocol: TCP
+      port: 9600       # Port the service will listen on for transport
+      targetPort: transport # Matches the 'transport' port name in the StatefulSet's podSpec (containerPort 9600)
+
+---
+# Headless Service for OpenSearch StatefulSet pod discovery
+# Provides stable DNS records for each pod (e.g., opensearch-0.opensearch-headless.opensearch.svc.cluster.local)
+apiVersion: v1
+kind: Service
+metadata:
+  name: opensearch-headless
+  namespace: opensearch
+  labels:
+    app: opensearch
+spec:
+  clusterIP: None # Defines the service as headless
+  selector:
     app: opensearch # Selects the OpenSearch pods
   ports:
-    - name: http
+    - name: http # Exposing http port here as well, though opensearch-service is primary for clients
+      port: 9200
+      targetPort: http
+    - name: transport # For node-to-node communication, essential for multi-node discovery via headless service
       protocol: TCP
-      port: 9200 # External port clients connect to
-      targetPort: http # Target port on the OpenSearch pods (containerPort name 'http')
-    - name: transport
-      protocol: TCP
-      port: 9600 # Also exposing transport port on ClusterIP if needed by some clients
-      targetPort: transport # Target port on the OpenSearch pods (containerPort name 'transport')
+      port: 9600
+      targetPort: transport

--- a/deploy/kubernetes/base/opensearch/statefulset.yaml
+++ b/deploy/kubernetes/base/opensearch/statefulset.yaml
@@ -6,8 +6,8 @@ metadata:
   labels:
     app: opensearch
 spec:
-  serviceName: "opensearch-headless" # Connects to the headless service for stable network ID
-  replicas: 1
+  serviceName: "opensearch-headless" # Must match the headless Service name
+  replicas: 1 # For base simplicity
   selector:
     matchLabels:
       app: opensearch
@@ -17,67 +17,72 @@ spec:
         app: opensearch
     spec:
       terminationGracePeriodSeconds: 30 # Allow time for OpenSearch to shut down gracefully
-      # OpenSearch recommends specific sysctl settings for performance (e.g., vm.max_map_count).
-      # This usually requires initContainers with privileged access or node-level configuration.
-      # For a base setup, we'll skip direct sysctl modification from the pod.
-      # initContainers:
-      # - name: configure-sysctl
-      #   image: busybox
-      #   command: ["sh", "-c", "sysctl -w vm.max_map_count=262144"]
-      #   securityContext:
-      #     privileged: true # Requires appropriate PSP/SCC
+      # OpenSearch official Docker images run as 'opensearch' user (UID 1000).
+      # If the storage provisioner creates volumes owned by root, fsGroup might be needed.
+      # However, many modern CSI drivers handle this, or the image itself manages permissions on /usr/share/opensearch/data.
+      # securityContext:
+      #   fsGroup: 1000 # Ensure the OpenSearch user can write to the volume
+      initContainers:
+      # Set vm.max_map_count required by OpenSearch. This needs privileged access or node configuration.
+      # This initContainer is best effort and might not work on all clusters depending on security policies.
+      - name: configure-sysctl
+        image: busybox:1.36 # Or any image with sysctl
+        command: ["sh", "-c", "sysctl -w vm.max_map_count=262144 || true"] # Attempt to set, proceed if it fails
+        securityContext:
+          privileged: true # Requires appropriate PSP/SCC or cluster configuration allowing privileged initContainers
       containers:
         - name: opensearch
-          image: opensearchproject/opensearch:1.2.0
+          image: opensearchproject/opensearch:1.2.0 # As specified
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
               add: ["IPC_LOCK"] # Required for bootstrap.memory_lock=true
-            # runAsUser: 1000 # OpenSearch image runs as opensearch user (UID 1000) by default
+            # runAsUser: 1000 # Usually not needed as image specifies user
             # runAsGroup: 1000
           ports:
-            - name: http
+            - name: http # REST API
               containerPort: 9200
               protocol: TCP
-            - name: transport
+            - name: transport # Node-to-node communication
               containerPort: 9600
               protocol: TCP
           env:
             - name: cluster.name
               value: "opensearch-cluster"
-            - name: node.name
-              # value: "opensearch-node1" # Fixed name, or use dynamic from pod name
-              valueFrom: # Use pod name for node.name for clarity if scaled (though single replica here)
+            - name: node.name # Set node name dynamically from pod metadata name
+              valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-            # For a single-node cluster, discovery can point to itself.
-            # The headless service provides a stable FQDN for the pod: opensearch-0.opensearch-headless.opensearch.svc.cluster.local
+            # For single-node cluster, discovery.seed_hosts can point to itself or be empty if discovery.type=single-node.
+            # Using FQDN of the pod for consistency if ever scaled, though single-node type handles it.
             - name: discovery.seed_hosts
               value: "opensearch-0.opensearch-headless.opensearch.svc.cluster.local"
             - name: cluster.initial_master_nodes # For bootstrapping a new cluster
-              value: "opensearch-0" # Pod name of the initial master
-            - name: bootstrap.memory_lock
-              value: "true" # Lock memory, ensure IPC_LOCK capability and host ulimits
-            - name: OPENSEARCH_JAVA_OPTS
-              value: "-Xms512m -Xmx512m" # Adjust heap size as needed
-            - name: DISABLE_INSTALL_DEMO_CONFIG # From compose, disables demo security plugin
+              valueFrom: # Use pod name (e.g. opensearch-0)
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: bootstrap.memory_lock # Lock JVM memory, ensure IPC_LOCK capability and host ulimits
               value: "true"
-            # For a single node cluster, these settings are typical
+            - name: OPENSEARCH_JAVA_OPTS # Configure JVM heap size
+              value: "-Xms512m -Xmx512m" # As specified
+            - name: DISABLE_INSTALL_DEMO_CONFIG # Disables demo security plugin for a non-secure base
+              value: "true"
+            # Crucial for single-node setup to avoid issues with discovery trying to find other masters.
             - name: discovery.type
-              value: "single-node" # Simplifies discovery for a single node setup
-            # - name: path.data # Default is /usr/share/opensearch/data, which is mounted
-            # - name: path.logs # Default is /usr/share/opensearch/logs, consider separate PVC for logs in production
-
+              value: "single-node"
+            # Optional: set path.data if it differs from the default /usr/share/opensearch/data
+            # - name: path.data
+            #   value: "/usr/share/opensearch/data"
           volumeMounts:
-            - name: opensearch-data
+            - name: data # Must match volumeClaimTemplates.metadata.name
               mountPath: /usr/share/opensearch/data
           readinessProbe:
             httpGet:
-              path: /_cluster/health?local=true # Check local node health
-              port: http # 9200
-              scheme: HTTP # Assuming HTTP for now, HTTPS if security is enabled
-            initialDelaySeconds: 20
-            periodSeconds: 10
+              path: /_cluster/health?local=true # Check local node health status
+              port: http # Port 9200
+              scheme: HTTP # Assuming HTTP for now, as demo security is disabled
+            initialDelaySeconds: 20 # OpenSearch can take some time to start
+            periodSeconds: 15
             timeoutSeconds: 5
             failureThreshold: 3
           livenessProbe:
@@ -85,11 +90,16 @@ spec:
               path: /_cluster/health?local=true
               port: http
               scheme: HTTP
-            initialDelaySeconds: 60 # Give more time for initial startup
+            initialDelaySeconds: 60 # More conservative for liveness
             periodSeconds: 30
-            timeoutSeconds: 5
-            failureThreshold: 5 # Be more tolerant for liveness
-      volumes:
-        - name: opensearch-data
-          persistentVolumeClaim:
-            claimName: opensearch-data-pvc
+            timeoutSeconds: 10 # Longer timeout for liveness
+            failureThreshold: 5
+  volumeClaimTemplates:
+  - metadata:
+      name: data # This name is referenced in volumeMounts.name
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 10Gi # As specified
+      # storageClassName: "your-storage-class" # Optional: specify if not using default SC.

--- a/deploy/kubernetes/base/optaplanner/configmap.yaml
+++ b/deploy/kubernetes/base/optaplanner/configmap.yaml
@@ -4,39 +4,32 @@ metadata:
   name: optaplanner-configmap
   namespace: optaplanner
 data:
-  # PostgreSQL connection details (used to construct JDBC URL)
-  # Assuming PostgreSQL is in 'postgres' namespace with service 'postgres-service':
-  DB_HOST: "postgres-service.postgres.svc.cluster.local"
-  DB_PORT: "5432"
-  DB_NAME: "atomicdb" # Or a dedicated DB for Optaplanner if preferred
-
-  # Quarkus Datasource Configuration
-  # QUARKUS_DATASOURCE_JDBC_URL is constructed by the application/entrypoint or explicitly here.
-  # For explicitness, we can define it here using the values above.
-  # Note: Direct variable substitution like $(DB_HOST) doesn't work in ConfigMap values.
-  # The application itself will need to be configured to build this URL from DB_HOST, DB_PORT, DB_NAME,
-  # or this ConfigMap provides the full URL if the app doesn't do such construction.
-  # Let's assume the app can take DB_HOST, DB_PORT, DB_NAME and construct the URL,
-  # or we can set the full URL here if that's how the app is configured.
-  # The prompt implies QUARKUS_DATASOURCE_JDBC_URL should be constructed.
-  # If the image's entrypoint doesn't do this, this value might need to be generated dynamically during deployment
-  # or the application code adapted.
-  # For now, I'll put the constructed string, assuming it's for reference or direct use if the app supports it.
-  # A better pattern is for the app to use DB_HOST, DB_PORT, DB_NAME vars.
-  # The prompt asks for QUARKUS_DATASOURCE_JDBC_URL to be constructed, so I will provide it as a fully formed string.
+  # Quarkus Datasource Configuration (credentials will be injected from secret)
+  # The JDBC URL should not contain username/password here.
+  # Quarkus will construct the full URL using QUARKUS_DATASOURCE_USERNAME and QUARKUS_DATASOURCE_PASSWORD from secrets.
   QUARKUS_DATASOURCE_JDBC_URL: "jdbc:postgresql://postgres-service.postgres.svc.cluster.local:5432/atomicdb"
   QUARKUS_DATASOURCE_DB-KIND: "postgresql"
 
-  # Optaplanner application user (for datasource, not Optaplanner's own API auth)
-  # This will be mapped to QUARKUS_DATASOURCE_USERNAME in the deployment.
-  USERNAME: "postgres" # This should match the POSTGRES_USER from the secret for the datasource.
+  # Optaplanner Application Authentication (distinct from database credentials)
+  # This USERNAME is for the Optaplanner application's own auth mechanism,
+  # paired with the PASSWORD (from API_TOKEN in secrets).
+  USERNAME: "admin"
 
-  # Optaplanner specific settings (non-sensitive)
-  # Example: if there are any specific Quarkus properties for OptaPlanner
-  # QUARKUS_OPTAPLANNER_SOLVER_TERMINATION_SPENT_LIMIT: "PT30S" # 30 seconds
+  # Quarkus HTTP Configuration
+  QUARKUS_HTTP_PORT: "8081" # Port the Quarkus application will listen on
 
-  # Application port (though often defined in Quarkus application.properties)
-  QUARKUS_HTTP_PORT: "8081" # Default Quarkus port is 8080, but compose uses 8081 for this service.
+  # Logging Configuration
+  QUARKUS_LOG_LEVEL: "INFO" # Default log level (INFO, DEBUG, WARN, ERROR)
+  # QUARKUS_LOG_CONSOLE_FORMAT: "%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c{3.}] (%t) %s%e%n" # Example format
 
-  # Logging level (example)
-  QUARKUS_LOG_LEVEL: "INFO"
+  # Optaplanner specific non-sensitive settings, if any
+  # Example:
+  # QUARKUS_OPTAPLANNER_SOLVER_ENVIRONMENT_MODE: "PRODUCTION" # Or REPRODUCIBLE, NON_INTRUSIVE_FULL_ASSERT, etc.
+  # QUARKUS_OPTAPLANNER_SOLVER_DAEMON: "false" # If not running as a daemon
+
+  # Any other non-sensitive configurations required by the Optaplanner service.
+  # For example, if DB_HOST, DB_PORT, DB_NAME were needed by an entrypoint script to construct the JDBC URL,
+  # but Quarkus typically handles this if QUARKUS_DATASOURCE_JDBC_URL, _USERNAME, _PASSWORD are set.
+  # DB_HOST: "postgres-service.postgres.svc.cluster.local"
+  # DB_PORT: "5432"
+  # DB_NAME: "atomicdb"

--- a/deploy/kubernetes/base/optaplanner/deployment.yaml
+++ b/deploy/kubernetes/base/optaplanner/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: optaplanner
 spec:
-  replicas: 1
+  replicas: 1 # As specified
   selector:
     matchLabels:
       app: optaplanner
@@ -17,33 +17,39 @@ spec:
     spec:
       containers:
         - name: optaplanner
-          image: "${PROJECT_NAME}-atomic-scheduler:latest" # Placeholder - replace with actual image URL
+          image: "placeholder-atomic-scheduler:latest" # Consistent placeholder name
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
-              containerPort: 8081 # Matches QUARKUS_HTTP_PORT in ConfigMap
+              containerPort: 8081 # Should match QUARKUS_HTTP_PORT from ConfigMap
               protocol: TCP
           env:
-            # Quarkus Datasource credentials from Secret
-            - name: QUARKUS_DATASOURCE_USERNAME # User for DB connection
+            # Database credentials from Secret
+            - name: QUARKUS_DATASOURCE_USERNAME # For Quarkus to connect to the DB
               valueFrom:
                 secretKeyRef:
                   name: optaplanner-secret
                   key: POSTGRES_USER
-            - name: QUARKUS_DATASOURCE_PASSWORD # Password for DB connection
+            - name: QUARKUS_DATASOURCE_PASSWORD # For Quarkus to connect to the DB
               valueFrom:
                 secretKeyRef:
                   name: optaplanner-secret
                   key: POSTGRES_PASSWORD
 
-            # Optaplanner application's own API authentication password from Secret
-            - name: PASSWORD # Used by Optaplanner for its /api basic auth or token auth
+            # Optaplanner application's own authentication credentials
+            # USERNAME is from ConfigMap, PASSWORD is from API_TOKEN in Secret
+            - name: USERNAME # For Optaplanner application auth
+              valueFrom:
+                configMapKeyRef:
+                  name: optaplanner-configmap
+                  key: USERNAME
+            - name: PASSWORD # For Optaplanner application auth (maps to API_TOKEN from secret)
               valueFrom:
                 secretKeyRef:
                   name: optaplanner-secret
                   key: API_TOKEN
 
-            # Other datasource and app config from ConfigMap
+            # Other configurations from ConfigMap
             - name: QUARKUS_DATASOURCE_JDBC_URL
               valueFrom:
                 configMapKeyRef:
@@ -54,13 +60,6 @@ spec:
                 configMapKeyRef:
                   name: optaplanner-configmap
                   key: QUARKUS_DATASOURCE_DB-KIND
-            # Note: The username for the datasource is taken from POSTGRES_USER secret directly
-            # The USERNAME in configmap was intended for this, but Quarkus expects QUARKUS_DATASOURCE_USERNAME.
-            # So, we map POSTGRES_USER from secret to QUARKUS_DATASOURCE_USERNAME.
-            # If Optaplanner app has a separate internal "admin" user concept (not DB user),
-            # that would be configured differently, e.g. with app-specific properties.
-            # The prompt's configmap had USERNAME: admin, but for datasource, it must match the actual DB user.
-
             - name: QUARKUS_HTTP_PORT
               valueFrom:
                 configMapKeyRef:
@@ -71,29 +70,13 @@ spec:
                 configMapKeyRef:
                   name: optaplanner-configmap
                   key: QUARKUS_LOG_LEVEL
-
-            # If DB_HOST, DB_PORT, DB_NAME are needed by the app to construct the JDBC URL itself:
-            # - name: DB_HOST
-            #   valueFrom:
-            #     configMapKeyRef:
-            #       name: optaplanner-configmap
-            #       key: DB_HOST
-            # - name: DB_PORT
-            #   valueFrom:
-            #     configMapKeyRef:
-            #       name: optaplanner-configmap
-            #       key: DB_PORT
-            # - name: DB_NAME
-            #   valueFrom:
-            #     configMapKeyRef:
-            #       name: optaplanner-configmap
-            #       key: DB_NAME
+            # Add other env vars from configmap if needed (e.g., QUARKUS_OPTAPLANNER_...)
 
           readinessProbe:
             httpGet:
               path: /q/health/ready # Standard Quarkus readiness probe
               port: http # Port 8081
-            initialDelaySeconds: 10
+            initialDelaySeconds: 15 # Allow time for Quarkus app to start and connect to DB
             periodSeconds: 15
             timeoutSeconds: 5
             failureThreshold: 3
@@ -101,7 +84,7 @@ spec:
             httpGet:
               path: /q/health/live # Standard Quarkus liveness probe
               port: http
-            initialDelaySeconds: 30
+            initialDelaySeconds: 45 # More conservative for liveness
             periodSeconds: 30
             timeoutSeconds: 5
             failureThreshold: 3

--- a/deploy/kubernetes/base/optaplanner/kustomization.yaml
+++ b/deploy/kubernetes/base/optaplanner/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: optaplanner
+namespace: optaplanner # Sets the namespace for all resources in this kustomization
 
 resources:
   - namespace.yaml
@@ -10,11 +10,13 @@ resources:
   - deployment.yaml
   - service.yaml
 
-# Optional: Add common labels to all resources
+# Optional: Add common labels to all resources defined in this kustomization
 # commonLabels:
 #   app.kubernetes.io/name: optaplanner
-#   app.kubernetes.io/part-of: atomic-stack
+#   app.kubernetes.io/instance: optaplanner
+#   app.kubernetes.io/component: scheduling-engine
+#   app.kubernetes.io/part-of: atomic-stack # Or your specific application/project name
 
 # Optional: Add common annotations
 # commonAnnotations:
-#   source: "https://github.com/your-repo/atomic-stack"
+#   note: "Optaplanner service base configuration"

--- a/deploy/kubernetes/base/optaplanner/secret.yaml
+++ b/deploy/kubernetes/base/optaplanner/secret.yaml
@@ -9,6 +9,6 @@ data:
   POSTGRES_USER: cG9zdGdyZXM= # "postgres"
   POSTGRES_PASSWORD: c2VjcmV0cGdwYXNzd29yZA== # "secretpgpassword"
 
-  # API_TOKEN for Optaplanner's own security (will be mapped to PASSWORD env var for the app)
-  # Also used by 'functions' service to authenticate with Optaplanner.
+  # API_TOKEN for Optaplanner's own security.
+  # This will be mapped to the 'PASSWORD' env var in the deployment for the application's auth.
   API_TOKEN: b3B0YXBsYW5uZXJfYXBpX3Rva2VuX3BsYWNlaG9sZGVy # "optaplanner_api_token_placeholder"

--- a/deploy/kubernetes/base/optaplanner/service.yaml
+++ b/deploy/kubernetes/base/optaplanner/service.yaml
@@ -6,11 +6,11 @@ metadata:
   labels:
     app: optaplanner
 spec:
-  type: ClusterIP
+  type: ClusterIP # Internal service
   selector:
-    app: optaplanner # Selects the optaplanner pods
+    app: optaplanner # Selects the Optaplanner pods
   ports:
     - name: http
       protocol: TCP
-      port: 8081 # Port the service will listen on
-      targetPort: http # Name of the port in the Deployment's podSpec (containerPort 8081)
+      port: 8081       # Port the service will listen on
+      targetPort: http # Matches the 'http' port name in the Deployment's podSpec (containerPort 8081)

--- a/deploy/kubernetes/base/postgres/kustomization.yaml
+++ b/deploy/kubernetes/base/postgres/kustomization.yaml
@@ -1,20 +1,22 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: postgres
+namespace: postgres # Sets the namespace for all resources in this kustomization
 
 resources:
   - namespace.yaml
   - secret.yaml
-  - pvc.yaml
+  # - pvc.yaml # Removed, as PVC is now defined via volumeClaimTemplates in statefulset.yaml
   - statefulset.yaml
   - service.yaml
 
-# Optional: Add common labels to all resources
+# Optional: Add common labels to all resources defined in this kustomization
 # commonLabels:
-#   app.kubernetes.io/name: postgres
-#   app.kubernetes.io/part-of: atomic-stack
+#   app.kubernetes.io/name: postgresql
+#   app.kubernetes.io/instance: postgres
+#   app.kubernetes.io/component: database
+#   app.kubernetes.io/part-of: atomic-stack # Or your specific application/project name
 
 # Optional: Add common annotations
 # commonAnnotations:
-#   source: "https://github.com/your-repo/atomic-stack"
+#   note: "PostgreSQL database service base configuration"

--- a/deploy/kubernetes/base/postgres/service.yaml
+++ b/deploy/kubernetes/base/postgres/service.yaml
@@ -1,16 +1,37 @@
+# ClusterIP Service for client connections to PostgreSQL
 apiVersion: v1
 kind: Service
 metadata:
-  name: postgres-service # This name is referenced in StatefulSet's serviceName
+  name: postgres-service
   namespace: postgres
   labels:
     app: postgres
 spec:
   type: ClusterIP
   selector:
-    app: postgres
+    app: postgres # Selects the PostgreSQL pods managed by the StatefulSet
   ports:
     - name: postgresql
       protocol: TCP
-      port: 5432
-      targetPort: postgresql # Refers to the container port name in StatefulSet podSpec
+      port: 5432       # Port the service will listen on
+      targetPort: postgresql # Matches the 'postgresql' port name in the StatefulSet's podSpec (containerPort 5432)
+
+---
+# Headless Service for PostgreSQL StatefulSet pod discovery
+# This service provides stable DNS records for each pod (e.g., postgres-0.postgres-headless.postgres.svc.cluster.local)
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres-headless
+  namespace: postgres
+  labels:
+    app: postgres
+spec:
+  clusterIP: None # Defines the service as headless
+  selector:
+    app: postgres # Selects the PostgreSQL pods
+  ports:
+    - name: postgresql
+      protocol: TCP
+      port: 5432       # Port for pod-to-pod communication if needed directly, or just for DNS record.
+      targetPort: postgresql # Matches the 'postgresql' port name in the StatefulSet's podSpec.

--- a/deploy/kubernetes/base/postgres/statefulset.yaml
+++ b/deploy/kubernetes/base/postgres/statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: postgres
 spec:
-  serviceName: "postgres-service" # Must match the Service name
+  serviceName: "postgres-headless" # Must match the headless Service name
   replicas: 1
   selector:
     matchLabels:
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
         - name: postgres
-          image: postgres:14-alpine
+          image: postgres:14-alpine # As specified
           imagePullPolicy: IfNotPresent
           ports:
             - name: postgresql
@@ -36,147 +36,57 @@ spec:
                 secretKeyRef:
                   name: postgres-secret
                   key: POSTGRES_PASSWORD
-            - name: POSTGRES_DB
-              value: "atomicdb"
-            - name: PGDATA
-              value: "/var/lib/postgresql/data/pgdata" # Ensures data is stored in the mounted volume subpath
+            - name: POSTGRES_DB # Name of the database to create
+              value: "atomicdb" # As specified
+            - name: PGDATA # Explicitly set the data directory path
+              value: "/var/lib/postgresql/data/pgdata" # Standard for official images when using a subpath in the volume
           volumeMounts:
-            - name: postgres-storage
+            - name: postgres-data # This name must match a volumeClaimTemplates.metadata.name
               mountPath: /var/lib/postgresql/data
           readinessProbe:
             exec:
               command:
-                - "pg_isready"
-                - "-U"
-                - "postgres" # This should match POSTGRES_USER from secret for robustness. Using placeholder for now.
-                - "-d"
-                - "atomicdb"
-            initialDelaySeconds: 10
+                - "sh"
+                - "-c"
+                # Use the user from the secret. Ensure this user can connect to the default 'postgres' db or POSTGRES_DB.
+                # pg_isready -U expects the username to be passed.
+                - "pg_isready -U $(POSTGRES_USER) -d $(POSTGRES_DB) -h 127.0.0.1 -p 5432"
+            env: # Pass credentials to the probe
+              - name: POSTGRES_USER
+                valueFrom:
+                  secretKeyRef:
+                    name: postgres-secret
+                    key: POSTGRES_USER
+              - name: POSTGRES_DB
+                value: "atomicdb"
+            initialDelaySeconds: 15
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 3
           livenessProbe:
             exec:
               command:
-                - "pg_isready"
-                - "-U"
-                - "postgres" # This should match POSTGRES_USER from secret for robustness. Using placeholder for now.
-                - "-d"
-                - "atomicdb"
-            initialDelaySeconds: 30
-            periodSeconds: 10
+                - "sh"
+                - "-c"
+                - "pg_isready -U $(POSTGRES_USER) -d $(POSTGRES_DB) -h 127.0.0.1 -p 5432"
+            env:
+              - name: POSTGRES_USER
+                valueFrom:
+                  secretKeyRef:
+                    name: postgres-secret
+                    key: POSTGRES_USER
+              - name: POSTGRES_DB
+                value: "atomicdb"
+            initialDelaySeconds: 45
+            periodSeconds: 15
             timeoutSeconds: 5
             failureThreshold: 3
   volumeClaimTemplates:
-    - metadata:
-        name: postgres-storage # Name of the volume claim template
-      spec:
-        accessModes: ["ReadWriteOnce"]
-        resources:
-          requests:
-            storage: 10Gi # Must match or exceed pvc.yaml if not using this for provisioning
-        # storageClassName: "" # Optional: specify a storage class if needed
-        # Note: The pvc.yaml created earlier is standalone.
-        # StatefulSets typically define volumeClaimTemplates to dynamically provision PVCs.
-        # If using the standalone postgres-pvc.yaml, the spec.template.spec.volumes section
-        # would reference it directly like in a Deployment, and volumeClaimTemplates would be removed.
-        # For this exercise, I'll keep volumeClaimTemplates as it's standard for StatefulSets.
-        # The standalone pvc.yaml might be redundant or for a different purpose if this is used.
-        # To use the existing PVC:
-        # Remove volumeClaimTemplates block.
-        # In spec.template.spec.volumes:
-        #   - name: postgres-storage
-        #     persistentVolumeClaim:
-        #       claimName: postgres-pvc
-        # For now, proceeding with volumeClaimTemplates as it's idiomatic for StatefulSets.
-        # This means the pvc.yaml is somewhat redundant if the StatefulSet manages its own PVC.
-        # Let's adjust to use the explicitly defined PVC to match the request structure.
-        # Will remove volumeClaimTemplates and adjust spec.template.spec.volumes.
----
-# Re-generating statefulset.yaml to use the pre-defined PVC for clarity with request.
-
-apiVersion: apps/v1
-kind: StatefulSet
-metadata:
-  name: postgres
-  namespace: postgres
-  labels:
-    app: postgres
-spec:
-  serviceName: "postgres-service"
-  replicas: 1
-  selector:
-    matchLabels:
-      app: postgres
-  template:
-    metadata:
-      labels:
-        app: postgres
+  - metadata:
+      name: postgres-data # This name is referenced in volumeMounts.name
     spec:
-      terminationGracePeriodSeconds: 10
-      containers:
-        - name: postgres
-          image: postgres:14-alpine
-          imagePullPolicy: IfNotPresent
-          ports:
-            - name: postgresql
-              containerPort: 5432
-              protocol: TCP
-          env:
-            - name: POSTGRES_USER
-              valueFrom:
-                secretKeyRef:
-                  name: postgres-secret
-                  key: POSTGRES_USER
-            - name: POSTGRES_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: postgres-secret
-                  key: POSTGRES_PASSWORD
-            - name: POSTGRES_DB
-              value: "atomicdb"
-            - name: PGDATA # Official Postgres image uses this to specify data directory
-              value: "/var/lib/postgresql/data/pgdata"
-          volumeMounts:
-            - name: postgres-storage
-              mountPath: /var/lib/postgresql/data
-          readinessProbe:
-            exec:
-              command:
-                - "sh"
-                - "-c"
-                - "pg_isready -U $(POSTGRES_USER) -d $(POSTGRES_DB)"
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 3
-            env: # Make sure POSTGRES_USER and POSTGRES_DB are available to the probe
-             - name: POSTGRES_USER
-               valueFrom:
-                 secretKeyRef:
-                   name: postgres-secret
-                   key: POSTGRES_USER
-             - name: POSTGRES_DB
-               value: "atomicdb"
-          livenessProbe:
-            exec:
-              command:
-                - "sh"
-                - "-c"
-                - "pg_isready -U $(POSTGRES_USER) -d $(POSTGRES_DB)"
-            initialDelaySeconds: 30
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 3
-            env: # Make sure POSTGRES_USER and POSTGRES_DB are available to the probe
-             - name: POSTGRES_USER
-               valueFrom:
-                 secretKeyRef:
-                   name: postgres-secret
-                   key: POSTGRES_USER
-             - name: POSTGRES_DB
-               value: "atomicdb"
-      volumes:
-        - name: postgres-storage
-          persistentVolumeClaim:
-            claimName: postgres-pvc # References the PVC created in pvc.yaml
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 10Gi # As specified
+      # storageClassName: "your-storage-class" # Optional: specify if not using default SC.

--- a/deploy/kubernetes/base/supertokens/deployment.yaml
+++ b/deploy/kubernetes/base/supertokens/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: supertokens-core
 spec:
-  replicas: 1
+  replicas: 1 # As specified, can be scaled as Supertokens core is generally stateless
   selector:
     matchLabels:
       app: supertokens-core
@@ -17,34 +17,14 @@ spec:
     spec:
       containers:
         - name: supertokens
-          image: registry.supertokens.io/supertokens/supertokens-postgresql:6.0
+          image: registry.supertokens.io/supertokens/supertokens-postgresql:6.0 # As specified
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
-              containerPort: 3567
+              containerPort: 3567 # Default Supertokens port
               protocol: TCP
           env:
-            # Construct POSTGRESQL_CONNECTION_URI from secret values
-            # This requires the shell to be available in the container to interpret the command.
-            # Most official images (including supertokens) have sh.
-            # An alternative is to use an initContainer to prepare the env var, but this is often sufficient.
-            - name: POSTGRESQL_CONNECTION_URI
-              valueFrom:
-                secretKeyRef:
-                  name: supertokens-db-secret
-                  key: DB_USER
-            # This is a bit tricky. We need to combine multiple secret values.
-            # A common way is to mount secrets as files and source them, or use an init container.
-            # However, for constructing a URI, we can try to do it with shell expansion if the entrypoint allows.
-            # Supertokens entrypoint might not directly expand this.
-            # Let's define them separately and assume the entrypoint script of Supertokens might construct it,
-            # or document that an init container or a custom entrypoint script is preferred for complex URI construction.
-            # For simplicity in this base manifest, we'll provide the components.
-            # The Supertokens container itself might be smart enough to pick up individual DB vars.
-            # Checking Supertokens docs: It primarily expects POSTGRESQL_CONNECTION_URI or individual vars like
-            # POSTGRESQL_USER, POSTGRESQL_PASSWORD, POSTGRESQL_HOST, POSTGRESQL_PORT, POSTGRESQL_DATABASE_NAME.
-            # Let's use those individual variables for clarity and reliability.
-
+            # Supertokens core can take individual PostgreSQL connection parameters
             - name: POSTGRESQL_USER
               valueFrom:
                 secretKeyRef:
@@ -65,33 +45,33 @@ spec:
                 secretKeyRef:
                   name: supertokens-db-secret
                   key: DB_PORT
-            - name: POSTGRESQL_DATABASE_NAME
+            - name: POSTGRESQL_DATABASE_NAME # Variable name used by Supertokens for DB name
               valueFrom:
                 secretKeyRef:
                   name: supertokens-db-secret
                   key: DB_NAME
-            - name: POSTGRESQL_TABLE_NAMES_PREFIX
-              value: "Supertokens" # As per original request
-            # Optional: API Keys, etc. would also come from secrets
-            # - name: API_KEYS
+            - name: POSTGRESQL_TABLE_NAMES_PREFIX # As specified
+              value: "Supertokens"
+            # Optional: API Keys, etc., would also come from secrets if needed by the core
+            # - name: api_keys
             #   valueFrom:
             #     secretKeyRef:
-            #       name: supertokens-api-keys
+            #       name: supertokens-api-keys # A different secret for API keys
             #       key: api_keys_string
 
           readinessProbe:
             httpGet:
               path: /hello # Supertokens health check endpoint
-              port: http # 3567
-            initialDelaySeconds: 5
+              port: http   # Port 3567
+            initialDelaySeconds: 10 # Allow time for Supertokens to connect to DB and start
             periodSeconds: 10
-            timeoutSeconds: 2
+            timeoutSeconds: 5
             failureThreshold: 3
           livenessProbe:
             httpGet:
               path: /hello
               port: http
-            initialDelaySeconds: 15
-            periodSeconds: 20
-            timeoutSeconds: 2
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            timeoutSeconds: 5
             failureThreshold: 3

--- a/deploy/kubernetes/base/supertokens/kustomization.yaml
+++ b/deploy/kubernetes/base/supertokens/kustomization.yaml
@@ -1,19 +1,22 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: supertokens
+namespace: supertokens # Sets the namespace for all resources in this kustomization
 
 resources:
   - namespace.yaml
   - secret.yaml
   - deployment.yaml
   - service.yaml
+  # No ConfigMap was specified for this service in the prompt.
 
-# Optional: Add common labels to all resources
+# Optional: Add common labels to all resources defined in this kustomization
 # commonLabels:
-#   app.kubernetes.io/name: supertokens-core
-#   app.kubernetes.io/part-of: atomic-stack
+#   app.kubernetes.io/name: supertokens
+#   app.kubernetes.io/instance: supertokens-core
+#   app.kubernetes.io/component: authentication
+#   app.kubernetes.io/part-of: atomic-stack # Or your specific application/project name
 
 # Optional: Add common annotations
 # commonAnnotations:
-#   source: "https://github.com/your-repo/atomic-stack"
+#   note: "Supertokens core service base configuration"

--- a/deploy/kubernetes/base/supertokens/secret.yaml
+++ b/deploy/kubernetes/base/supertokens/secret.yaml
@@ -9,7 +9,6 @@ data:
   DB_PASSWORD: c2VjcmV0cGdwYXNzd29yZA== # "secretpgpassword"
   # DB_HOST should be the address of the PostgreSQL service.
   # Assuming PostgreSQL is in 'postgres' namespace with service 'postgres-service':
-  # postgres-service.postgres.svc.cluster.local
-  DB_HOST: cG9zdGdyZXMtc2VydmljZS5wb3N0Z3Jlcy5zdmMuY2x1c3Rlci5sb2NhbA==
+  DB_HOST: cG9zdGdyZXMtc2VydmljZS5wb3N0Z3Jlcy5zdmMuY2x1c3Rlci5sb2NhbA== # "postgres-service.postgres.svc.cluster.local"
   DB_PORT: NTQzMg== # "5432"
   DB_NAME: YXRvbWljZGI= # "atomicdb"

--- a/deploy/kubernetes/base/supertokens/service.yaml
+++ b/deploy/kubernetes/base/supertokens/service.yaml
@@ -6,11 +6,11 @@ metadata:
   labels:
     app: supertokens-core
 spec:
-  type: ClusterIP
+  type: ClusterIP # Internal service, not exposed externally by default
   selector:
     app: supertokens-core # Selects the Supertokens pods
   ports:
     - name: http
       protocol: TCP
-      port: 3567 # Port the service will listen on
-      targetPort: http # Name of the port in the Deployment's podSpec (containerPort 3567)
+      port: 3567       # Port the service will listen on
+      targetPort: http # Matches the 'http' port name in the Deployment's podSpec (containerPort 3567)


### PR DESCRIPTION
This commit includes the fully implemented Terraform HCL code for the AWS infrastructure and the complete set of base Kubernetes manifests (Kustomize) for all services in the 'atomic' application stack.

Key Assets Implemented:

1.  **AWS Terraform Infrastructure (`deploy/aws/terraform/` - Complete):**
    *   Networking: VPC, subnets, IGW, NATs, route tables, SGs with EKS focus.
    *   EKS Cluster: Control plane, node groups with launch templates for
      custom security group attachment, IAM roles, OIDC.
    *   ECR: Repositories for all custom application images.
    *   Secrets Manager: Placeholders for all application secrets with
      `ignore_changes` lifecycle for secure value management.
    *   RDS for PostgreSQL: Instance with password sourced from Secrets Manager.
    *   IAM: Role for CodeBuild (CI/CD) and a comprehensive IRSA example.
    *   Common Files: Centralized provider, versions, variables, and outputs.

2.  **Base Kubernetes Manifests (`deploy/kubernetes/base/` - Complete):**
    *   YAML manifests (Namespaces, Deployments/StatefulSets with
      volumeClaimTemplates, Services, ConfigMaps, placeholder Secrets)
      generated for ALL services: Traefik, MinIO, PostgreSQL (in-cluster),
      Kafka (Zookeeper & Broker), OpenSearch, Supertokens, Hasura,
      `functions`, `optaplanner`, `handshake`, `oauth`, and `app`.
    *   Each service has its own Kustomization file.
    *   A root `kustomization.yaml` aggregates all base services.
    *   Image names use placeholders (e.g., `placeholder-atomic-servicename`)
      for Kustomize overlay overrides.

Current Status & Next Steps:
The AWS IaC and the common Kubernetes base manifests are now fully implemented (conceptually). The next step is to implement the AWS-specific Kustomize overlays, which will handle AWS Secrets Manager integration (via CSI driver), ECR image paths, and AWS Load Balancer annotations for Traefik.