### PR TITLE
feat: Implement Azure Terraform and Kustomize overlays

### DIFF
--- a/deploy/azure/terraform/acr.tf
+++ b/deploy/azure/terraform/acr.tf
@@ -1,0 +1,119 @@
+# --- Variables ---
+variable "azure_region" {
+  description = "The Azure region where the ACR will be deployed."
+  type        = string
+}
+
+variable "resource_group_name" {
+  description = "The name of the Azure Resource Group where ACR will be deployed."
+  type        = string
+}
+
+variable "project_name" {
+  description = "Name of the project, used for tagging and constructing the ACR name."
+  type        = string
+}
+
+variable "acr_name_suffix" {
+  description = "A suffix for the ACR name to help ensure global uniqueness. The full name will be <project_name><suffix>."
+  type        = string
+  default     = "acr" # Example: myprojectacr
+}
+
+variable "acr_sku" {
+  description = "The SKU for the Azure Container Registry (e.g., Basic, Standard, Premium)."
+  type        = string
+  default     = "Standard" # Standard is a good balance for most use cases
+  validation {
+    condition     = contains(["Basic", "Standard", "Premium"], var.acr_sku)
+    error_message = "ACR SKU must be one of: Basic, Standard, Premium."
+  }
+}
+
+variable "aks_cluster_system_assigned_identity_principal_id" {
+  description = "The Principal ID of the System Assigned Managed Identity of the AKS cluster. Used for granting AcrPull role."
+  type        = string
+  # This value would typically be an output from the aks_cluster.tf module:
+  # azurerm_kubernetes_cluster.main.identity[0].principal_id
+}
+
+
+# --- Azure Container Registry (ACR) ---
+# ACR names must be globally unique, alphanumeric, and 5-50 characters.
+# We'll construct a name and then sanitize it.
+locals {
+  # Attempt to create a compliant ACR name. Users should verify this or provide a fully compliant acr_name directly.
+  raw_acr_name    = lower("${var.project_name}${var.acr_name_suffix}")
+  sanitized_acr_name = substr(replace(local.raw_acr_name, "/[^a-z0-9]/", ""), 0, 50) # Remove non-alphanumeric, take first 50 chars
+}
+
+resource "azurerm_container_registry" "main" {
+  name                = local.sanitized_acr_name # Globally unique name for the ACR
+  resource_group_name = var.resource_group_name
+  location            = var.azure_region
+  sku                 = var.acr_sku
+  admin_enabled       = false # Recommended to disable admin user and use token/service principal/MI based auth
+
+  # Optional: Geo-replications for high availability and performance across regions
+  # georeplications {
+  #   location                = "East US" # Example additional region
+  #   zone_redundancy_enabled = true      # If the region supports AZs
+  #   tags                    = {}
+  # }
+
+  # Optional: Network rule set for restricting access
+  # network_rule_set {
+  #   default_action = "Deny" # Deny by default
+  #   ip_rule = [
+  #     {
+  #       action = "Allow"
+  #       ip_range = "YOUR_CI_CD_IP_RANGE" # Example: Allow CI/CD IP
+  #     }
+  #   ]
+  #   # virtual_network allows access from specific VNet subnets (e.g., for AKS if using private link)
+  # }
+
+  tags = {
+    environment = "Production" # Or as per your tagging strategy
+    project     = var.project_name
+    terraform   = "true"
+  }
+}
+
+# --- IAM Role Assignment for AKS to Pull from ACR ---
+# Grant the AKS cluster's system-assigned managed identity the "AcrPull" role on this ACR.
+# This allows Kubelet on AKS nodes to pull images from this ACR.
+
+resource "azurerm_role_assignment" "aks_pull_from_acr" {
+  scope                = azurerm_container_registry.main.id
+  role_definition_name = "AcrPull" # Built-in role for pulling images
+  principal_id         = var.aks_cluster_system_assigned_identity_principal_id
+
+  # The principal_type for a System-Assigned Managed Identity is "ServicePrincipal".
+  # principal_type       = "ServicePrincipal" # Optional: can often be inferred
+
+  # Note: If you later configure AKS node pools to use User-Assigned Managed Identities (UMIs)
+  # for Kubelet, you would need to grant the "AcrPull" role to those UMIs instead of,
+  # or in addition to, the cluster's system-assigned identity.
+  # This setup assumes the cluster's main identity (or the default Kubelet identity derived from it)
+  # is sufficient for pulling images. This is common for basic AKS setups.
+  # If a dedicated User-Assigned MI is created for Kubelet (e.g., in managed_identity.tf),
+  # its principal_id should be used here instead.
+}
+
+# --- Outputs (typically in outputs.tf) ---
+# Moved to outputs.tf as per best practice.
+# output "acr_id" {
+#   description = "The ID of the Azure Container Registry."
+#   value       = azurerm_container_registry.main.id
+# }
+#
+# output "acr_name" {
+#   description = "The name of the Azure Container Registry."
+#   value       = azurerm_container_registry.main.name
+# }
+#
+# output "acr_login_server" {
+#   description = "The login server hostname of the Azure Container Registry (e.g., myacr.azurecr.io)."
+#   value       = azurerm_container_registry.main.login_server
+# }

--- a/deploy/azure/terraform/aks_cluster.tf
+++ b/deploy/azure/terraform/aks_cluster.tf
@@ -1,0 +1,214 @@
+# --- Variables ---
+variable "azure_region" {
+  description = "The Azure region where the AKS cluster will be deployed."
+  type        = string
+}
+
+variable "resource_group_name" {
+  description = "The name of the Azure Resource Group where AKS will be deployed."
+  type        = string
+}
+
+variable "project_name" {
+  description = "Name of the project, used for tagging and naming resources."
+  type        = string
+}
+
+variable "aks_cluster_name" {
+  description = "The name for the AKS cluster."
+  type        = string
+}
+
+variable "aks_kubernetes_version" {
+  description = "Desired Kubernetes version for the AKS cluster."
+  type        = string
+  default     = "1.27.9" # Specify a recent, supported version. Check Azure for latest patch.
+}
+
+variable "aks_default_node_pool_name" {
+  description = "Name for the default node pool in AKS."
+  type        = string
+  default     = "agentpool" # Standard default name
+}
+
+variable "aks_default_node_count" {
+  description = "Initial number of nodes in the default node pool."
+  type        = number
+  default     = 2
+}
+
+variable "aks_default_node_vm_size" {
+  description = "VM size for the nodes in the default node pool (e.g., Standard_DS2_v2)."
+  type        = string
+  default     = "Standard_DS2_v2"
+}
+
+variable "aks_subnet_id" {
+  description = "The ID of the subnet where AKS nodes will be deployed (output from vnet.tf)."
+  type        = string
+  # Example: azurerm_subnet.aks.id
+}
+
+variable "log_analytics_workspace_id" {
+  description = "The resource ID of the Log Analytics workspace for Azure Monitor for containers. Optional."
+  type        = string
+  default     = null # If null, Azure Monitor integration will be disabled or use default workspace.
+}
+
+variable "aks_service_cidr" {
+  description = "CIDR for Kubernetes services within AKS."
+  type        = string
+  default     = "10.2.0.0/16"
+}
+
+variable "aks_dns_service_ip" {
+  description = "IP address for the DNS service within AKS (must be within service_cidr)."
+  type        = string
+  default     = "10.2.0.10"
+}
+
+variable "aks_docker_bridge_cidr" {
+  description = "CIDR for the Docker bridge network on nodes."
+  type        = string
+  default     = "172.17.0.1/16"
+}
+
+# --- Azure Kubernetes Service (AKS) Cluster ---
+resource "azurerm_kubernetes_cluster" "main" {
+  name                = var.aks_cluster_name
+  location            = var.azure_region
+  resource_group_name = var.resource_group_name
+  dns_prefix          = "${var.project_name}-aks-${lower(replace(var.azure_region, " ", ""))}" # Needs to be globally unique in Azure DNS if public
+  kubernetes_version  = var.aks_kubernetes_version
+
+  default_node_pool {
+    name                = var.aks_default_node_pool_name
+    node_count          = var.aks_default_node_count
+    vm_size             = var.aks_default_node_vm_size
+    vnet_subnet_id      = var.aks_subnet_id # Associate with the dedicated AKS subnet
+    # enable_auto_scaling = true
+    # min_count           = 1
+    # max_count           = 3
+    # type                = "VirtualMachineScaleSets" # Default
+    tags = {
+      "nodepool-type" = "system" # Or "user" for additional node pools
+      "environment"   = "Production" # Or as per your tagging strategy
+      "project"       = var.project_name
+    }
+  }
+
+  identity {
+    type = "SystemAssigned" # Use SystemAssigned MI for the cluster control plane for simplicity.
+                            # UserAssigned MI can be used for more granular control plane identity.
+                            # Kubelet identity (for node permissions) is separate and can be UserAssigned MI.
+                            # This is set up in managed_identity.tf and associated with node pools there or via default_node_pool.
+  }
+
+  network_profile {
+    network_plugin     = "azure"  # Use Azure CNI for better performance and VNet integration
+    network_policy     = "azure"  # Use Azure Network Policy (requires Azure CNI). Alternatively "calico".
+    service_cidr       = var.aks_service_cidr
+    dns_service_ip     = var.aks_dns_service_ip
+    docker_bridge_cidr = var.aks_docker_bridge_cidr
+    # load_balancer_sku = "Standard" # Default is Standard
+  }
+
+  # Azure Monitor for containers integration
+  oms_agent {
+    log_analytics_workspace_id = var.log_analytics_workspace_id
+    # msi_auth_for_monitoring_enabled = true # Use Managed Identity for OMS agent authentication (recommended)
+                                         # This would typically use the Kubelet identity or a dedicated one.
+  }
+
+  # Addon Profiles
+  addon_profile {
+    # Azure Key Vault Provider for Secrets Store CSI Driver
+    # This addon is crucial for integrating Azure Key Vault with Kubernetes for secret management.
+    azure_keyvault_secrets_provider {
+      enabled = true
+      # secret_rotation_enabled  = true # Optional: enable automatic rotation of secrets
+      # secret_rotation_interval = "2m"  # Optional: rotation interval
+    }
+
+    # Other common addons (examples, can be enabled as needed)
+    # http_application_routing { # For easy Ingress setup with nip.io DNS - good for dev/test
+    #   enabled = false
+    # }
+    # azure_policy {
+    #   enabled = false
+    # }
+    # ingress_application_gateway { # If using AGIC
+    #   enabled = false
+    # }
+  }
+
+  # --- Optional: Azure AD Integration for Kubernetes RBAC ---
+  # azure_active_directory_role_based_access_control {
+  #   managed                = true
+  #   admin_group_object_ids = ["YOUR_AZURE_AD_ADMIN_GROUP_OBJECT_ID"] # Object ID of an AAD group for cluster admins
+  #   # azure_rbac_enabled     = true # For authorizing K8s API access using Azure RBAC roles (distinct from K8s RBAC)
+  #   # tenant_id              = "YOUR_AZURE_TENANT_ID"
+  # }
+
+  # --- Optional: Private Cluster ---
+  # private_cluster_enabled = true
+  # To make the API server private. Requires careful network planning (e.g., VNet peering, VPN, ExpressRoute for kubectl access).
+
+  tags = {
+    environment = "Production"
+    project     = var.project_name
+    terraform   = "true"
+  }
+}
+
+# --- Outputs (typically in outputs.tf) ---
+# Moved to outputs.tf as per best practice.
+# output "aks_cluster_id" {
+#   description = "The ID of the AKS cluster."
+#   value       = azurerm_kubernetes_cluster.main.id
+# }
+#
+# output "aks_cluster_name_output" {
+#   description = "The name of the AKS cluster."
+#   value       = azurerm_kubernetes_cluster.main.name
+# }
+#
+# output "aks_kube_config_raw" {
+#   description = "Raw Kubeconfig for the AKS cluster. Sensitive."
+#   value       = azurerm_kubernetes_cluster.main.kube_config_raw
+#   sensitive   = true
+# }
+#
+# output "aks_kube_config" { # For direct use by Kubernetes provider if needed
+#   description = "Kubeconfig block for the AKS cluster."
+#   value       = azurerm_kubernetes_cluster.main.kube_config
+#   sensitive   = true
+# }
+#
+# output "aks_system_assigned_identity_principal_id" {
+#   description = "The Principal ID of the System Assigned Managed Identity for the AKS cluster control plane."
+#   value       = azurerm_kubernetes_cluster.main.identity[0].principal_id
+# }
+#
+# output "aks_system_assigned_identity_tenant_id" {
+#   description = "The Tenant ID of the System Assigned Managed Identity for the AKS cluster control plane."
+#   value       = azurerm_kubernetes_cluster.main.identity[0].tenant_id
+# }
+#
+# output "aks_node_resource_group" {
+#   description = "The name of the auto-generated resource group where AKS worker nodes and other resources are deployed (MC_resourcegroupname_clustername_region)."
+#   value       = azurerm_kubernetes_cluster.main.node_resource_group
+# }
+#
+# output "aks_oidc_issuer_url" { # For Workload Identity
+#   description = "The OIDC issuer URL for the AKS cluster."
+#   value       = azurerm_kubernetes_cluster.main.oidc_issuer_url
+# }
+#
+# output "aks_kubelet_identity_object_id" { # If default_node_pool uses SystemAssigned MI by default, or if UserAssigned MI is configured here
+#   description = "Object ID of the Kubelet identity (Managed Identity used by nodes)."
+#   value       = azurerm_kubernetes_cluster.main.kubelet_identity[0].object_id # Only if default_node_pool creates/uses one with known output here.
+                                                                              # This might be better sourced from a separate node pool resource or MI resource.
+                                                                              # For `SystemAssigned` on default_node_pool, this value is populated.
+                                                                              # If user-assigned MI is used for Kubelet, it's configured elsewhere and its ID passed in.
+# }

--- a/deploy/azure/terraform/key_vault.tf
+++ b/deploy/azure/terraform/key_vault.tf
@@ -1,4 +1,7 @@
-# Variables to be defined in variables.tf or passed as input
+# --- Data Sources ---
+data "azurerm_client_config" "current" {} # To get current tenant_id if not provided
+
+# --- Variables ---
 variable "azure_region" {
   description = "The Azure region where resources will be deployed."
   type        = string
@@ -14,55 +17,55 @@ variable "project_name" {
   type        = string
 }
 
-variable "key_vault_name" {
-  description = "The name of the Azure Key Vault. Must be globally unique."
+variable "key_vault_name_suffix" {
+  description = "A suffix for the Key Vault name to help ensure global uniqueness. Full name will be <project_name>-kv-<suffix> or similar."
   type        = string
+  default     = "kv"
 }
 
 variable "key_vault_sku_name" {
   description = "The SKU name for the Azure Key Vault (e.g., 'standard', 'premium')."
   type        = string
   default     = "standard"
+  validation {
+    condition     = contains(["standard", "premium"], var.key_vault_sku_name)
+    error_message = "Key Vault SKU must be either 'standard' or 'premium'."
+  }
 }
 
 variable "tenant_id" {
-  description = "The Azure Tenant ID where the Key Vault and identity reside."
+  description = "The Azure Tenant ID where the Key Vault and identity reside. If empty, it's fetched from current client config."
   type        = string
-  # This can often be sourced from the Azure provider configuration or data source:
-  # data "azurerm_client_config" "current" {}
-  # default = data.azurerm_client_config.current.tenant_id
+  default     = ""
 }
 
 variable "secrets_to_create_in_kv" {
-  description = "A map of secrets to create in Azure Key Vault. Key is the secret name, value is a description (or can be an object with more attributes if needed)."
+  description = "A map of secrets to create in Azure Key Vault. Key is the secret name (use hyphens), value is a description."
   type        = map(string)
   default = {
     # Database Secrets
-    "POSTGRES-USER"                = "Username for Azure Database for PostgreSQL." # Or reference to a specific user identity if managed separately
+    "POSTGRES-USER"                = "Username for Azure Database for PostgreSQL."
     "POSTGRES-PASSWORD"            = "Password for Azure Database for PostgreSQL."
 
     # Hasura Secrets
     "HASURA-GRAPHQL-ADMIN-SECRET"  = "Admin secret for Hasura GraphQL engine."
-    # HASURA_GRAPHQL_JWT_SECRET is a JSON structure. Key Vault can store it as a string.
     "HASURA-GRAPHQL-JWT-SECRET"    = "JWT secret for Hasura GraphQL engine (JSON format)."
 
-    # MinIO/Storage Secrets
-    "STORAGE-ACCESS-KEY"           = "Access key for Azure Blob Storage or MinIO."
-    "STORAGE-SECRET-KEY"           = "Secret key for Azure Blob Storage or MinIO."
+    # Storage/MinIO Secrets (generic names if secrets are for MinIO running in K8s, or for Azure Blob HMAC keys)
+    "STORAGE-ACCESS-KEY"           = "Access key for Azure Blob Storage HMAC or MinIO."
+    "STORAGE-SECRET-KEY"           = "Secret key for Azure Blob Storage HMAC or MinIO."
 
     # Functions Service Secrets (examples)
     "OPENAI-API-KEY"               = "API key for OpenAI services."
-    "BASIC-AUTH-FUNCTIONS-ADMIN"   = "Basic authentication credentials for -admin endpoints in functions service (e.g., user:pass)."
-    "GOOGLE-CLIENT-ID-ATOMIC-WEB"  = "Google Client ID for Atomic Web application (used by Functions)."
+    "BASIC-AUTH-FUNCTIONS-ADMIN"   = "Basic authentication credentials for -admin endpoints in functions service."
+    "GOOGLE-CLIENT-ID-ATOMIC-WEB"  = "Google Client ID for Atomic Web application (used by Functions)." # This is a Google OAuth Client ID
     "ZOOM-CLIENT-SECRET"           = "Zoom Client Secret (used by Functions)."
 
-    # Add other secrets based on the list from the AWS secrets_manager.tf, adapting names for Key Vault if needed.
-    # Hyphens are generally preferred over underscores in Azure resource naming conventions where possible for secrets.
+    # Other secrets, using hyphens for Key Vault secret names
     "TRAEFIK-USER"                     = "Username for Traefik dashboard basic authentication."
     "TRAEFIK-PASSWORD"                 = "Password for Traefik dashboard basic authentication."
     "GOOGLE-CLIENT-ID-ANDROID"         = "Google Client ID for Android application."
     "GOOGLE-CLIENT-ID-IOS"             = "Google Client ID for iOS application."
-    # "GOOGLE_CLIENT_ID_WEB"           - already covered by ATOMIC_WEB or similar, or add if distinct
     "GOOGLE-CLIENT-SECRET-ATOMIC-WEB"  = "Google Client Secret for Atomic Web application."
     "GOOGLE-CLIENT-SECRET-WEB"         = "Google Client Secret for Web application."
     "KAFKA-USERNAME"                   = "Username for Kafka SASL authentication (if enabled)."
@@ -70,7 +73,7 @@ variable "secrets_to_create_in_kv" {
     "OPENSEARCH-USERNAME"              = "Username for OpenSearch security (if enabled)."
     "OPENSEARCH-PASSWORD"              = "Password for OpenSearch security (if enabled)."
     "ZOOM-PASS-KEY"                    = "Zoom Pass Key for encryption."
-    "ZOOM-CLIENT-ID"                   = "Zoom Client ID." # Used by oauth and potentially functions
+    "ZOOM-CLIENT-ID"                   = "Zoom Client ID."
     "ZOOM-SALT-FOR-PASS"               = "Zoom Salt for Pass Key."
     "ZOOM-IV-FOR-PASS"                 = "Zoom IV for Pass Key."
     "ZOOM-WEBHOOK-SECRET-TOKEN"        = "Zoom Webhook Secret Token."
@@ -78,35 +81,49 @@ variable "secrets_to_create_in_kv" {
   }
 }
 
-variable "aks_kubelet_identity_object_id" {
-  description = "The Object ID of the AKS Kubelet's Managed Identity (e.g., user-assigned MI for agentpool) or the AKS Cluster's main identity that CSI driver will use."
+variable "aks_secret_accessor_identity_object_id" {
+  description = "The Object ID of the Managed Identity (User-Assigned for Kubelet/CSI-driver-specific, or System-Assigned for AKS control plane if that's used by CSI driver) that needs access to Key Vault secrets."
   type        = string
-  # This should be an output from the AKS cluster resource definition (e.g., azurerm_kubernetes_cluster.main.kubelet_identity[0].object_id)
-  # or the specific identity configured for the Secrets Store CSI Driver Azure provider.
+  # This should be the object_id of the identity that the Secrets Store CSI Driver Azure provider will use.
+  # If using User-Assigned MI for node pools (and Kubelet uses it for KV access), this is its object ID.
+  # If using Workload Identity for the CSI driver's own SA, this would be the GSA's object ID (less common for Azure KV provider).
+  # For AKS Key Vault Addon, it often uses the Kubelet identity.
 }
+
+# --- Azure Key Vault Name Construction ---
+# Key Vault names must be globally unique, 3-24 alphanumeric characters and hyphens, start with letter, end with letter/digit.
+locals {
+  # Attempt to create a compliant Key Vault name.
+  # Users should verify this or provide a fully compliant key_vault_name directly if this logic is insufficient.
+  raw_kv_name      = lower("${var.project_name}-kv-${var.key_vault_name_suffix}")
+  sanitized_kv_name = substr(replace(local.raw_kv_name, "/[^a-z0-9-]/", ""), 0, 24) # Remove non-alphanumeric-hyphen, limit length
+  # Further ensure it starts with a letter and doesn't end with a hyphen (more complex regex might be needed for perfect auto-compliance)
+  # For simplicity, this basic sanitization is provided. User should ensure `project_name` and `key_vault_name_suffix` are sensible.
+  final_key_vault_name = length(local.sanitized_kv_name) < 3 ? "kv${local.sanitized_kv_name}xyz" : local.sanitized_kv_name # Ensure min length
+}
+
 
 # --- Azure Key Vault Resource ---
 resource "azurerm_key_vault" "main" {
-  name                        = var.key_vault_name
+  name                        = local.final_key_vault_name
   location                    = var.azure_region
   resource_group_name         = var.resource_group_name
-  tenant_id                   = var.tenant_id # Explicitly set tenant_id
-  sku_name                    = var.key_vault_sku_name # e.g., "standard" or "premium"
-  enable_rbac_authorization   = true       # Enable RBAC for Key Vault data plane operations
+  tenant_id                   = var.tenant_id != "" ? var.tenant_id : data.azurerm_client_config.current.tenant_id
+  sku_name                    = var.key_vault_sku_name
+  enable_rbac_authorization   = true       # Enable RBAC for Key Vault data plane operations (recommended)
 
-  # Soft delete and purge protection are recommended for production
-  soft_delete_retention_days  = 7 # Or your desired retention period (7-90 days)
-  purge_protection_enabled    = true # Recommended for production to prevent accidental permanent deletion
+  soft_delete_retention_days  = 7
+  purge_protection_enabled    = true # Recommended for production
 
   network_acls {
     default_action = "Deny"    # Deny by default
     bypass         = "AzureServices" # Allows trusted Azure services to bypass
-    # ip_rules       = []      # Allowed IP addresses/ranges (e.g., for CI/CD access if needed)
-    # virtual_network_subnet_ids = [] # Allowed VNet subnets (e.g., for specific service access if not using private endpoints)
+    # ip_rules       = []      # Allowed IP addresses/ranges (e.g., for CI/CD to populate secrets)
+    # virtual_network_subnet_ids = [] # Subnets that can access KV (e.g., if not using private endpoints)
   }
 
   tags = {
-    environment = "Production"
+    environment = "Production" # Or as per your tagging strategy
     project     = var.project_name
     terraform   = "true"
   }
@@ -116,15 +133,13 @@ resource "azurerm_key_vault" "main" {
 resource "azurerm_key_vault_secret" "app_secrets" {
   for_each = var.secrets_to_create_in_kv
 
-  name         = each.key # Secret name in Key Vault
+  name         = each.key # Secret name in Key Vault (e.g., "POSTGRES-PASSWORD")
   value        = "TO-BE-SET-MANUALLY-OR-VIA-CICD" # Placeholder value
   key_vault_id = azurerm_key_vault.main.id
-  content_type = "text/plain" # Or application/json if storing JSON
+  content_type = "text/plain" # Or "application/json" if storing JSON stringified objects
 
-  # This lifecycle block ensures that Terraform does not try to revert changes
-  # made to the secret value outside of Terraform after initial creation.
   lifecycle {
-    ignore_changes = [value]
+    ignore_changes = [value] # Prevents Terraform from overwriting externally managed secret values
   }
 
   tags = {
@@ -134,38 +149,42 @@ resource "azurerm_key_vault_secret" "app_secrets" {
   }
 }
 
-# --- RBAC Role Assignment for AKS Kubelet Identity to access Key Vault Secrets ---
-# This allows the identity used by the Secrets Store CSI Driver Azure provider (often Kubelet MI)
-# to read secrets from this Key Vault.
+# --- RBAC Role Assignment for AKS Identity to access Key Vault Secrets ---
+# This allows the identity used by the Secrets Store CSI Driver Azure provider
+# (e.g., Kubelet MI or a User-Assigned MI for node pool) to read secrets.
 
-# Data source to get built-in role definition for "Key Vault Secrets User"
-data "azurerm_role_definition" "key_vault_secrets_user" {
-  name = "Key Vault Secrets User" # Built-in role
+data "azurerm_role_definition" "key_vault_secrets_user_role" {
+  name = "Key Vault Secrets User" # Built-in role for reading secret contents
 }
 
-resource "azurerm_role_assignment" "aks_to_key_vault_secrets" {
+resource "azurerm_role_assignment" "aks_identity_to_key_vault_secrets" {
   scope                = azurerm_key_vault.main.id # Assign role at the Key Vault scope
-  role_definition_name = data.azurerm_role_definition.key_vault_secrets_user.name
-  principal_id         = var.aks_kubelet_identity_object_id # Object ID of the AKS Kubelet MI or other designated identity
+  role_definition_name = data.azurerm_role_definition.key_vault_secrets_user_role.name
+  principal_id         = var.aks_secret_accessor_identity_object_id # Object ID of the MI (Kubelet MI or other)
 
-  # The principal_type for a User-Assigned Managed Identity is "ServicePrincipal".
-  # If using a System-Assigned Managed Identity (e.g., from the AKS cluster itself),
-  # its object_id would also typically correspond to a ServicePrincipal representing that identity.
-  # principal_type       = "ServicePrincipal" # Optional: can often be inferred
+  # principal_type can be "User", "Group", or "ServicePrincipal".
+  # For Managed Identities (System-Assigned or User-Assigned), the principal_id is that of a Service Principal.
+  # principal_type       = "ServicePrincipal" # Often optional, Azure can infer for MI object IDs.
 }
 
-# Outputs
-output "key_vault_id" {
-  description = "The ID of the Azure Key Vault."
-  value       = azurerm_key_vault.main.id
-}
-
-output "key_vault_uri" {
-  description = "The URI of the Azure Key Vault."
-  value       = azurerm_key_vault.main.vault_uri
-}
-
-output "key_vault_secret_ids" {
-  description = "A map of the IDs of the created Key Vault secrets."
-  value       = { for k, v in azurerm_key_vault_secret.app_secrets : k => v.id }
-}
+# --- Outputs (typically in outputs.tf) ---
+# Moved to outputs.tf as per best practice.
+# output "key_vault_id" {
+#   description = "The ID of the Azure Key Vault."
+#   value       = azurerm_key_vault.main.id
+# }
+#
+# output "key_vault_uri" {
+#   description = "The URI of the Azure Key Vault."
+#   value       = azurerm_key_vault.main.vault_uri
+# }
+#
+# output "key_vault_secret_uris_map" { # Changed from _ids to _uris for more direct usability sometimes
+#   description = "A map of the logical secret name to its full URI in Azure Key Vault."
+#   value       = { for k, v in azurerm_key_vault_secret.app_secrets : k => v.versionless_id } # versionless_id points to latest
+# }
+#
+# output "key_vault_secret_names_map" {
+#   description = "A map of the logical secret name to its name in Key Vault."
+#   value       = { for k, v in azurerm_key_vault_secret.app_secrets : k => v.name }
+# }

--- a/deploy/azure/terraform/managed_identity.tf
+++ b/deploy/azure/terraform/managed_identity.tf
@@ -1,0 +1,147 @@
+# --- Variables ---
+variable "azure_region" {
+  description = "The Azure region where resources will be deployed."
+  type        = string
+}
+
+variable "resource_group_name" {
+  description = "The name of the Azure Resource Group."
+  type        = string
+}
+
+variable "project_name" {
+  description = "Name of the project, used for tagging and naming resources."
+  type        = string
+}
+
+variable "aks_kubelet_mi_name_suffix" {
+  description = "Suffix for the User-Assigned Managed Identity for AKS Kubelet."
+  type        = string
+  default     = "aks-kubelet-mi"
+}
+
+variable "acr_id_for_mi_assignment" {
+  description = "The ID of the Azure Container Registry for AcrPull role assignment."
+  type        = string
+  # This would typically be an output from acr.tf: azurerm_container_registry.main.id
+}
+
+variable "key_vault_id_for_mi_assignment" {
+  description = "The ID of the Azure Key Vault for Key Vault Secrets User role assignment."
+  type        = string
+  # This would typically be an output from key_vault.tf: azurerm_key_vault.main.id
+}
+
+# --- User-Assigned Managed Identity for AKS Kubelet ---
+# This identity will be assigned to the AKS node pool(s) (specifically to the kubelet_identity block).
+# It allows nodes to pull images from ACR and access Key Vault secrets via the CSI driver.
+resource "azurerm_user_assigned_identity" "aks_kubelet_mi" {
+  name                = "${var.project_name}-${var.aks_kubelet_mi_name_suffix}"
+  resource_group_name = var.resource_group_name
+  location            = var.azure_region
+
+  tags = {
+    environment = "Production" # Or as per your tagging strategy
+    project     = var.project_name
+    purpose     = "AKS Kubelet Identity"
+    terraform   = "true"
+  }
+}
+
+# --- Role Assignments for the Kubelet User-Assigned Managed Identity ---
+
+# 1. Grant "AcrPull" role to the Kubelet MI on the ACR scope
+resource "azurerm_role_assignment" "kubelet_mi_acr_pull" {
+  scope                = var.acr_id_for_mi_assignment
+  role_definition_name = "AcrPull" # Built-in role for pulling images from ACR
+  principal_id         = azurerm_user_assigned_identity.aks_kubelet_mi.principal_id
+
+  # principal_type is "ServicePrincipal" for User-Assigned Identities.
+  # This is often inferred by Azure but can be specified.
+  # principal_type       = "ServicePrincipal"
+}
+
+# 2. Grant "Key Vault Secrets User" role to the Kubelet MI on the Key Vault scope
+# This allows the Secrets Store CSI Driver, using this Kubelet identity, to read secrets.
+data "azurerm_role_definition" "key_vault_secrets_user_role_for_mi" { # Renamed data source to avoid conflict if defined elsewhere
+  name = "Key Vault Secrets User" # Built-in role
+}
+
+resource "azurerm_role_assignment" "kubelet_mi_key_vault_secrets_user" {
+  scope                = var.key_vault_id_for_mi_assignment
+  role_definition_name = data.azurerm_role_definition.key_vault_secrets_user_role_for_mi.name
+  principal_id         = azurerm_user_assigned_identity.aks_kubelet_mi.principal_id
+  # principal_type       = "ServicePrincipal"
+}
+
+# --- (Optional) Example: Service Principal for CI/CD ---
+# This section is commented out and serves as a template for creating a Service Principal
+# that a CI/CD system (like GitHub Actions, Jenkins, Azure DevOps) could use to deploy resources.
+# This SP would typically need roles like "Contributor" on the resource group, "AcrPush" on ACR,
+# and potentially "Key Vault Secrets Officer" or specific secret set permissions.
+
+/*
+resource "azuread_application" "cicd_app_registration" {
+  display_name = "${var.project_name}-cicd-app"
+}
+
+resource "azuread_service_principal" "cicd_sp" {
+  application_id = azuread_application.cicd_app_registration.application_id
+}
+
+# Store Service Principal password as a secret in Azure Key Vault or GitHub Actions secrets
+resource "azuread_service_principal_password" "cicd_sp_password" {
+  service_principal_id = azuread_service_principal.cicd_sp.object_id
+  description          = "Password for ${var.project_name} CI/CD Service Principal"
+  end_date_relative    = "2400h" # e.g., 100 days
+}
+
+# Example Role Assignment for CI/CD SP (e.g., AcrPush)
+resource "azurerm_role_assignment" "cicd_sp_acr_push" {
+  scope                = var.acr_id_for_mi_assignment # Assuming CI/CD pushes to the same ACR
+  role_definition_name = "AcrPush"
+  principal_id         = azuread_service_principal.cicd_sp.object_id
+}
+
+# Example Role Assignment for CI/CD SP (e.g., Key Vault Secrets Officer to set secret values)
+data "azurerm_role_definition" "key_vault_secrets_officer_role" {
+  name = "Key Vault Secrets Officer"
+}
+resource "azurerm_role_assignment" "cicd_sp_kv_secrets_officer" {
+  scope                = var.key_vault_id_for_mi_assignment
+  role_definition_name = data.azurerm_role_definition.key_vault_secrets_officer_role.name
+  principal_id         = azuread_service_principal.cicd_sp.object_id
+}
+
+# Output CI/CD Service Principal details (handle sensitive data appropriately)
+output "cicd_sp_application_id" {
+  description = "Application (Client) ID for the CI/CD Service Principal."
+  value       = azuread_application.cicd_app_registration.application_id
+}
+output "cicd_sp_object_id" {
+  description = "Object ID for the CI/CD Service Principal."
+  value       = azuread_service_principal.cicd_sp.object_id
+}
+output "cicd_sp_password_value" {
+  description = "Password for the CI/CD Service Principal (handle with extreme care - store in secure location)."
+  value       = azuread_service_principal_password.cicd_sp_password.value
+  sensitive   = true
+}
+*/
+
+# --- Outputs (typically in outputs.tf) ---
+# Moved to outputs.tf as per best practice.
+# output "aks_kubelet_user_assigned_identity_id" {
+#   description = "The ID of the User-Assigned Managed Identity for AKS Kubelet."
+#   value       = azurerm_user_assigned_identity.aks_kubelet_mi.id
+# }
+#
+# output "aks_kubelet_user_assigned_identity_principal_id" {
+#   description = "The Principal ID of the User-Assigned Managed Identity for AKS Kubelet. This is needed for role assignments and to assign to AKS node pool."
+#   value       = azurerm_user_assigned_identity.aks_kubelet_mi.principal_id
+# }
+#
+# output "aks_kubelet_user_assigned_identity_client_id" {
+#   description = "The Client ID of the User-Assigned Managed Identity for AKS Kubelet."
+#   value       = azurerm_user_assigned_identity.aks_kubelet_mi.client_id
+# }

--- a/deploy/azure/terraform/outputs.tf
+++ b/deploy/azure/terraform/outputs.tf
@@ -1,0 +1,182 @@
+# --- VNet Outputs ---
+output "vnet_id_output" {
+  description = "The ID of the created Azure Virtual Network."
+  value       = azurerm_virtual_network.main.id
+}
+
+output "vnet_name_output" {
+  description = "The name of the created Azure Virtual Network."
+  value       = azurerm_virtual_network.main.name
+}
+
+output "aks_subnet_id_output" {
+  description = "The ID of the AKS subnet."
+  value       = azurerm_subnet.aks.id
+}
+
+output "aks_subnet_cidr_output" { # Renamed from aks_subnet_address_prefix for clarity
+  description = "The CIDR block of the AKS subnet."
+  value       = azurerm_subnet.aks.address_prefixes[0]
+}
+
+output "application_subnet_id_output" {
+  description = "The ID of the application subnet."
+  value       = azurerm_subnet.application.id
+}
+
+output "database_subnet_id_output" {
+  description = "The ID of the database subnet."
+  value       = azurerm_subnet.database.id
+}
+
+output "database_subnet_cidr_output" { # Renamed from database_subnet_address_prefix
+  description = "The CIDR block of the database subnet."
+  value       = azurerm_subnet.database.address_prefixes[0]
+}
+
+# --- NSG Outputs ---
+output "aks_subnet_nsg_id_output" {
+  description = "The ID of the AKS Subnet Network Security Group."
+  value       = azurerm_network_security_group.aks_subnet_nsg.id
+}
+
+output "db_subnet_nsg_id_output" {
+  description = "The ID of the Database Subnet Network Security Group."
+  value       = azurerm_network_security_group.db_subnet_nsg.id
+}
+
+# --- AKS Cluster Outputs ---
+output "aks_cluster_id_output" {
+  description = "The ID of the AKS cluster."
+  value       = azurerm_kubernetes_cluster.main.id
+}
+
+output "aks_cluster_name_output" {
+  description = "The name of the AKS cluster."
+  value       = azurerm_kubernetes_cluster.main.name
+}
+
+output "aks_kube_config_raw_output" {
+  description = "Raw Kubeconfig for the AKS cluster. Contains sensitive credentials."
+  value       = azurerm_kubernetes_cluster.main.kube_config_raw
+  sensitive   = true
+}
+
+output "aks_kube_config_output" {
+  description = "Kubeconfig block for the AKS cluster (can be used by Kubernetes provider)."
+  value       = azurerm_kubernetes_cluster.main.kube_config
+  sensitive   = true
+}
+
+output "aks_cluster_system_assigned_identity_principal_id_output" {
+  description = "The Principal ID of the System Assigned Managed Identity for the AKS cluster control plane."
+  value       = azurerm_kubernetes_cluster.main.identity[0].principal_id
+}
+
+output "aks_cluster_system_assigned_identity_tenant_id_output" {
+  description = "The Tenant ID of the System Assigned Managed Identity for the AKS cluster control plane."
+  value       = azurerm_kubernetes_cluster.main.identity[0].tenant_id
+}
+
+output "aks_node_resource_group_output" {
+  description = "The name of the auto-generated resource group where AKS worker nodes and other resources are deployed."
+  value       = azurerm_kubernetes_cluster.main.node_resource_group
+}
+
+output "aks_oidc_issuer_url_output" {
+  description = "The OIDC issuer URL for the AKS cluster, used for Workload Identity."
+  value       = azurerm_kubernetes_cluster.main.oidc_issuer_url
+}
+
+# Output for Kubelet Managed Identity (User-Assigned or System-Assigned from default_node_pool)
+# This was commented out in aks_cluster.tf as potentially better from a dedicated MI resource.
+# If default_node_pool uses SystemAssigned MI (default behavior if no user_assigned_identity_id is set), this is available.
+# If default_node_pool is configured to use the User-Assigned MI created in managed_identity.tf,
+# then that MI's object_id is what's relevant for KV access by CSI driver using Kubelet identity.
+output "aks_default_node_pool_kubelet_identity_object_id_output" {
+  description = "Object ID of the Kubelet identity for the default node pool. This is the identity used by the Secrets Store CSI driver if configured to use Kubelet identity."
+  value       = azurerm_kubernetes_cluster.main.kubelet_identity[0].object_id
+  # Note: This assumes the default_node_pool's Kubelet identity is what's used for KV access by CSI driver.
+  # If a separate User-Assigned MI is created and assigned to the node pool for this purpose (as per managed_identity.tf),
+  # then that MI's principal_id (aks_kubelet_user_assigned_identity_principal_id_output) is the one to grant KV access to.
+}
+
+
+# --- ACR Outputs ---
+output "acr_id_output" {
+  description = "The ID of the Azure Container Registry."
+  value       = azurerm_container_registry.main.id
+}
+
+output "acr_name_output" {
+  description = "The name of the Azure Container Registry."
+  value       = azurerm_container_registry.main.name
+}
+
+output "acr_login_server_output" {
+  description = "The login server hostname of the Azure Container Registry."
+  value       = azurerm_container_registry.main.login_server
+}
+
+# --- Key Vault Outputs ---
+output "key_vault_id_output" {
+  description = "The ID of the Azure Key Vault."
+  value       = azurerm_key_vault.main.id
+}
+
+output "key_vault_uri_output" {
+  description = "The URI of the Azure Key Vault."
+  value       = azurerm_key_vault.main.vault_uri
+}
+
+output "key_vault_secret_uris_map_output" {
+  description = "A map of the logical secret name to its versionless URI in Azure Key Vault."
+  value       = { for k, v in azurerm_key_vault_secret.app_secrets : k => v.versionless_id }
+}
+
+output "key_vault_secret_names_map_output" {
+  description = "A map of the logical secret name to its name in Key Vault."
+  value       = { for k, v in azurerm_key_vault_secret.app_secrets : k => v.name }
+}
+
+# --- PostgreSQL Flexible Server Outputs ---
+output "pg_flexible_server_id_output" {
+  description = "The ID of the PostgreSQL Flexible Server."
+  value       = azurerm_postgresql_flexible_server.main.id
+}
+
+output "pg_flexible_server_fqdn_output" {
+  description = "The Fully Qualified Domain Name of the PostgreSQL Flexible Server."
+  value       = azurerm_postgresql_flexible_server.main.fqdn
+}
+
+output "pg_flexible_server_admin_username_output" {
+  description = "The administrator username for the PostgreSQL Flexible Server."
+  value       = azurerm_postgresql_flexible_server.main.administrator_login
+}
+
+output "pg_flexible_server_initial_database_name_output" {
+  description = "The name of the initial database created on the PostgreSQL Flexible Server."
+  value       = azurerm_postgresql_flexible_server_database.initial_db.name
+}
+
+output "pg_private_dns_zone_name_output" {
+  description = "The name of the private DNS zone created for the PostgreSQL server."
+  value       = azurerm_private_dns_zone.pg_private_dns_zone.name
+}
+
+# --- Managed Identity Outputs (User-Assigned Kubelet MI) ---
+output "aks_kubelet_user_assigned_identity_id_output" {
+  description = "The ID of the User-Assigned Managed Identity for AKS Kubelet."
+  value       = azurerm_user_assigned_identity.aks_kubelet_mi.id
+}
+
+output "aks_kubelet_user_assigned_identity_principal_id_output" {
+  description = "The Principal ID of the User-Assigned Managed Identity for AKS Kubelet."
+  value       = azurerm_user_assigned_identity.aks_kubelet_mi.principal_id
+}
+
+output "aks_kubelet_user_assigned_identity_client_id_output" {
+  description = "The Client ID of the User-Assigned Managed Identity for AKS Kubelet."
+  value       = azurerm_user_assigned_identity.aks_kubelet_mi.client_id
+}

--- a/deploy/azure/terraform/postgresql.tf
+++ b/deploy/azure/terraform/postgresql.tf
@@ -1,0 +1,212 @@
+# --- Variables ---
+variable "azure_region" {
+  description = "The Azure region where the PostgreSQL Flexible Server will be deployed."
+  type        = string
+}
+
+variable "resource_group_name" {
+  description = "The name of the Azure Resource Group."
+  type        = string
+}
+
+variable "project_name" {
+  description = "Name of the project, used for tagging and naming resources."
+  type        = string
+}
+
+variable "pg_server_name_suffix" {
+  description = "A suffix for the PostgreSQL Flexible Server name to help ensure global uniqueness. Full name will be <project_name>-pgs-<suffix>."
+  type        = string
+  default     = "pgs01" # PostgreSQL Server 01
+}
+
+variable "pg_admin_username" {
+  description = "Administrator username for the PostgreSQL Flexible Server."
+  type        = string
+  default     = "pgatomicadmin"
+}
+
+variable "pg_sku_name" {
+  description = "SKU name for the PostgreSQL Flexible Server (e.g., GP_Standard_D2s_v3, B_Standard_B1ms)."
+  type        = string
+  default     = "B_Standard_B1ms" # Burstable, good for dev/test or low-load prod
+}
+
+variable "pg_version" {
+  description = "PostgreSQL major version (e.g., 13, 14, 15, 16)."
+  type        = string
+  default     = "14" # Specify a recent, supported version
+}
+
+variable "pg_storage_mb" {
+  description = "Storage size in MB for the PostgreSQL Flexible Server."
+  type        = number
+  default     = 32768 # 32 GB (minimum for some SKUs/features)
+}
+
+variable "pg_backup_retention_days" {
+  description = "Backup retention period in days (7-35 days)."
+  type        = number
+  default     = 7
+}
+
+variable "pg_geo_redundant_backup_enabled" {
+  description = "Enable geo-redundant backups."
+  type        = bool
+  default     = false # Set to true for production disaster recovery needs
+}
+
+variable "db_subnet_id" {
+  description = "The ID of the subnet to which the PostgreSQL Flexible Server should be delegated (output from vnet.tf)."
+  type        = string
+  # Example: azurerm_subnet.database.id
+}
+
+variable "vnet_id_for_dns_link" { # Added this variable
+  description = "The ID of the Virtual Network to link with the Private DNS Zone."
+  type        = string
+  # Example: azurerm_virtual_network.main.id
+}
+
+variable "pg_initial_database_name" {
+  description = "The name of the initial database to be created on the PostgreSQL server."
+  type        = string
+  default     = "atomicdb"
+}
+
+# Key Vault Integration Variables
+variable "key_vault_id_for_pg_password" {
+  description = "The ID of the Azure Key Vault where the PostgreSQL admin password secret is stored."
+  type        = string
+  # Example: azurerm_key_vault.main.id (from key_vault.tf)
+}
+
+variable "pg_admin_password_secret_name" {
+  description = "The name of the secret in Azure Key Vault that stores the PostgreSQL admin password."
+  type        = string
+  default     = "POSTGRES-PASSWORD" # Must match the secret name created in key_vault.tf
+}
+
+# --- PostgreSQL Server Name Construction ---
+locals {
+  # PostgreSQL Flexible Server names must be globally unique.
+  raw_pg_server_name    = lower("${var.project_name}-${var.pg_server_name_suffix}")
+  # Replace non-alphanumeric except hyphens, ensure it starts/ends with alphanumeric, limit length (3-63 chars).
+  # This is a simplified sanitization. A more robust regex might be needed for all edge cases.
+  sanitized_pg_server_name = substr(replace(local.raw_pg_server_name, "/[^a-z0-9-]/", ""), 0, 63)
+  # Ensure it doesn't start or end with a hyphen (can be complex with just substr/replace)
+  # For simplicity, users should ensure project_name and suffix result in a valid start/end.
+  final_pg_server_name = length(local.sanitized_pg_server_name) < 3 ? "pgs${local.sanitized_pg_server_name}xyz" : local.sanitized_pg_server_name
+}
+
+# --- Data Source to Fetch PostgreSQL Admin Password from Azure Key Vault ---
+data "azurerm_key_vault_secret" "pg_admin_password" {
+  name         = var.pg_admin_password_secret_name
+  key_vault_id = var.key_vault_id_for_pg_password
+}
+
+# --- Private DNS Zone for PostgreSQL Flexible Server ---
+# Using a private DNS zone allows resolution of the server's FQDN to its private IP within the VNet.
+# The zone name is typically <server_name>.postgres.database.azure.com for Flexible Server.
+resource "azurerm_private_dns_zone" "pg_private_dns_zone" {
+  name                = "${local.final_pg_server_name}.postgres.database.azure.com"
+  resource_group_name = var.resource_group_name # Often good to place DNS zone in same RG as VNet or a dedicated DNS RG
+
+  tags = {
+    environment = "Production"
+    project     = var.project_name
+    terraform   = "true"
+  }
+}
+
+# --- Link Private DNS Zone to the Virtual Network ---
+resource "azurerm_private_dns_zone_virtual_network_link" "pg_dns_vnet_link" {
+  name                  = "${local.final_pg_server_name}-vnet-link"
+  resource_group_name   = var.resource_group_name
+  private_dns_zone_name = azurerm_private_dns_zone.pg_private_dns_zone.name
+  virtual_network_id    = var.vnet_id_for_dns_link # Link to the main VNet
+  registration_enabled  = false # Auto-registration not typically used for PaaS like Flexible Server's own records
+
+  tags = {
+    environment = "Production"
+    project     = var.project_name
+    terraform   = "true"
+  }
+}
+
+# --- Azure Database for PostgreSQL Flexible Server ---
+resource "azurerm_postgresql_flexible_server" "main" {
+  name                   = local.final_pg_server_name
+  resource_group_name    = var.resource_group_name
+  location               = var.azure_region
+  version                = var.pg_version
+  administrator_login    = var.pg_admin_username
+  administrator_password = data.azurerm_key_vault_secret.pg_admin_password.value # Fetched from Key Vault
+
+  delegated_subnet_id    = var.db_subnet_id # VNet Integration using subnet delegation
+  private_dns_zone_id    = azurerm_private_dns_zone.pg_private_dns_zone.id # Link to our private DNS zone
+
+  sku_name               = var.pg_sku_name
+  storage_mb             = var.pg_storage_mb
+
+  backup_retention_days  = var.pg_backup_retention_days
+  geo_redundant_backup_enabled = var.pg_geo_redundant_backup_enabled
+
+  # Ensure public network access is disabled to rely on VNet integration
+  public_network_access_enabled = false
+
+  # Availability zone (optional, can be set to 1, 2, or 3 if region supports it and SKU allows)
+  # zone = "1"
+
+  # High availability (optional, requires certain SKUs and regions)
+  # high_availability {
+  #   mode = "ZoneRedundant" # Or "SameZone"
+  #   # standby_availability_zone = "2" # If mode is ZoneRedundant and you want to specify standby AZ
+  # }
+
+  tags = {
+    environment = "Production"
+    project     = var.project_name
+    terraform   = "true"
+  }
+
+  depends_on = [
+    data.azurerm_key_vault_secret.pg_admin_password,
+    azurerm_private_dns_zone_virtual_network_link.pg_dns_vnet_link # Ensure DNS setup is ready
+  ]
+}
+
+# --- Initial Database Creation ---
+resource "azurerm_postgresql_flexible_server_database" "initial_db" {
+  name      = var.pg_initial_database_name
+  server_id = azurerm_postgresql_flexible_server.main.id
+  charset   = "UTF8"
+  collation = "en_US.utf8" # Or your preferred collation
+}
+
+# --- Outputs (typically in outputs.tf) ---
+# Moved to outputs.tf as per best practice.
+# output "pg_flexible_server_id" {
+#   description = "The ID of the PostgreSQL Flexible Server."
+#   value       = azurerm_postgresql_flexible_server.main.id
+# }
+#
+# output "pg_flexible_server_fqdn" {
+#   description = "The Fully Qualified Domain Name of the PostgreSQL Flexible Server. Resolves to a private IP within the VNet."
+#   value       = azurerm_postgresql_flexible_server.main.fqdn
+# }
+#
+# output "pg_flexible_server_admin_username" {
+#   description = "The administrator username for the PostgreSQL Flexible Server."
+#   value       = azurerm_postgresql_flexible_server.main.administrator_login # or var.pg_admin_username
+# }
+#
+# output "pg_flexible_server_initial_database_name" {
+#   description = "The name of the initial database created on the PostgreSQL Flexible Server."
+#   value       = azurerm_postgresql_flexible_server_database.initial_db.name
+# }
+#
+# output "pg_private_dns_zone_name" {
+#   description = "The name of the private DNS zone created for the PostgreSQL server."
+#   value       = azurerm_private_dns_zone.pg_private_dns_zone.name
+# }

--- a/deploy/azure/terraform/provider.tf
+++ b/deploy/azure/terraform/provider.tf
@@ -1,0 +1,50 @@
+# Terraform Azure Provider Configuration
+
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.75" # Specify a compatible version range for the Azure provider
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5" # For generating unique names if needed
+    }
+    # azuread = { # Uncomment if using the azuread provider for CI/CD SP example in managed_identity.tf
+    #   source  = "hashicorp/azuread"
+    #   version = "~> 2.40"
+    # }
+  }
+}
+
+# Azure Provider Block
+# Authentication:
+# The Azure provider supports several ways to authenticate:
+# 1. Azure CLI: If you are logged in via `az login`, Terraform will use these credentials. (Common for local dev)
+# 2. Service Principal: For CI/CD pipelines, create a Service Principal and set ARM_CLIENT_ID, ARM_CLIENT_SECRET, ARM_SUBSCRIPTION_ID, ARM_TENANT_ID as environment variables.
+# 3. Managed Identity: If Terraform is running on an Azure resource with a Managed Identity (e.g., Azure VM, Azure DevOps agent).
+provider "azurerm" {
+  features {
+    # Specific features for Azure resources can be configured here if needed.
+    # For example, for Key Vault:
+    # key_vault {
+    #   purge_soft_delete_on_destroy    = true # Or false depending on desired behavior
+    #   recover_soft_deleted_key_vaults = true
+    # }
+    # resource_group {
+    #   prevent_deletion_if_contains_resources = false
+    # }
+  }
+
+  # Optional: Specify subscription ID if not using the default from Azure CLI context or environment variables.
+  # subscription_id = "YOUR_AZURE_SUBSCRIPTION_ID"
+
+  # Optional: Specify tenant ID if not using the default.
+  # tenant_id = "YOUR_AZURE_TENANT_ID" # Often taken from azurerm_client_config data source or env var
+}
+
+# Variables used by the provider block or for default_tags (if azurerm supported it directly like AWS)
+# Azure provider does not have a direct `default_tags` block like AWS.
+# Tags are applied per resource or via azurerm_resource_group_template_deployment for RG level tagging.
+# We will apply tags directly in each resource definition.
+# Variables like region, project_name, environment_name are defined in variables.tf.

--- a/deploy/azure/terraform/variables.tf
+++ b/deploy/azure/terraform/variables.tf
@@ -1,0 +1,309 @@
+# --- Global Azure Configuration Variables ---
+variable "azure_region" {
+  description = "The Azure region where all resources will be deployed."
+  type        = string
+  default     = "East US" # Example default, adjust as needed
+}
+
+variable "resource_group_name" {
+  description = "The name of the Azure Resource Group to deploy resources into. It's assumed this RG already exists or is created separately."
+  type        = string
+  # default     = "atomic-rg" # Example: Should be created or specified by user.
+}
+
+variable "project_name" {
+  description = "A short name for your project (e.g., atomic, myapp). Used for resource prefixing and tagging."
+  type        = string
+  default     = "atomic"
+}
+
+variable "environment_name" {
+  description = "Deployment environment (e.g., dev, staging, prod). Used for tagging and resource naming."
+  type        = string
+  default     = "dev"
+}
+
+variable "tenant_id" {
+  description = "The Azure Tenant ID where resources reside. If empty, it's fetched from current client config."
+  type        = string
+  default     = "" # Will use data.azurerm_client_config.current.tenant_id if empty
+}
+
+# --- VNet and Subnet Configuration Variables ---
+variable "vnet_cidr" {
+  description = "The CIDR block for the Azure Virtual Network."
+  type        = string
+  default     = "10.1.0.0/16"
+}
+
+variable "aks_subnet_cidr" {
+  description = "The CIDR block for the AKS subnet."
+  type        = string
+  default     = "10.1.1.0/24"
+}
+
+variable "application_subnet_cidr" {
+  description = "The CIDR block for the general application subnet."
+  type        = string
+  default     = "10.1.2.0/24"
+}
+
+variable "database_subnet_cidr" {
+  description = "The CIDR block for the database subnet."
+  type        = string
+  default     = "10.1.3.0/24"
+}
+
+# --- NSG Configuration Variables (aks_subnet_cidr already defined) ---
+# NSG names are derived from project_name.
+
+# --- AKS Cluster Configuration Variables ---
+variable "aks_cluster_name_suffix" {
+  description = "Suffix for the AKS cluster name. Full name will be ${var.project_name}-aks-${var.aks_cluster_name_suffix}-${var.environment_name} or similar."
+  type        = string
+  default     = "cluster"
+}
+
+variable "aks_kubernetes_version" {
+  description = "Desired Kubernetes version for the AKS cluster."
+  type        = string
+  default     = "1.27.9" # Check Azure for latest supported patch versions.
+}
+
+variable "aks_default_node_pool_name" {
+  description = "Name for the default node pool in AKS."
+  type        = string
+  default     = "agentpool"
+}
+
+variable "aks_default_node_count" {
+  description = "Initial number of nodes in the default node pool."
+  type        = number
+  default     = 2
+}
+
+variable "aks_default_node_vm_size" {
+  description = "VM size for the nodes in the default node pool."
+  type        = string
+  default     = "Standard_DS2_v2"
+}
+
+variable "log_analytics_workspace_id" {
+  description = "The resource ID of the Log Analytics workspace for Azure Monitor for containers. Optional. If not provided, AKS monitoring might use a default or not be fully enabled."
+  type        = string
+  default     = null
+}
+
+variable "aks_service_cidr" {
+  description = "CIDR for Kubernetes services within AKS."
+  type        = string
+  default     = "10.2.0.0/16"
+}
+
+variable "aks_dns_service_ip" {
+  description = "IP address for the DNS service within AKS (must be within service_cidr)."
+  type        = string
+  default     = "10.2.0.10"
+}
+
+variable "aks_docker_bridge_cidr" {
+  description = "CIDR for the Docker bridge network on nodes."
+  type        = string
+  default     = "172.17.0.1/16"
+}
+
+# --- ACR (Azure Container Registry) Configuration Variables ---
+variable "acr_name_suffix" {
+  description = "A suffix for the ACR name to help ensure global uniqueness. Full name will be <project_name><suffix>."
+  type        = string
+  default     = "acr"
+}
+
+variable "acr_sku" {
+  description = "The SKU for the Azure Container Registry (Basic, Standard, Premium)."
+  type        = string
+  default     = "Standard"
+  validation {
+    condition     = contains(["Basic", "Standard", "Premium"], var.acr_sku)
+    error_message = "ACR SKU must be one of: Basic, Standard, Premium."
+  }
+}
+
+# --- Key Vault Configuration Variables ---
+variable "key_vault_name_suffix" {
+  description = "A suffix for the Key Vault name to help ensure global uniqueness. Full name will be <project_name>-kv-<suffix> or similar."
+  type        = string
+  default     = "kv"
+}
+
+variable "key_vault_sku_name" {
+  description = "The SKU name for the Azure Key Vault (standard or premium)."
+  type        = string
+  default     = "standard"
+  validation {
+    condition     = contains(["standard", "premium"], var.key_vault_sku_name)
+    error_message = "Key Vault SKU must be either 'standard' or 'premium'."
+  }
+}
+
+variable "secrets_to_create_in_kv" {
+  description = "A map of secrets to create in Azure Key Vault. Key is secret name (hyphenated), value is description."
+  type        = map(string)
+  default = { # Default from key_vault.tf
+    "POSTGRES-USER"                = "Username for Azure Database for PostgreSQL."
+    "POSTGRES-PASSWORD"            = "Password for Azure Database for PostgreSQL."
+    "HASURA-GRAPHQL-ADMIN-SECRET"  = "Admin secret for Hasura GraphQL engine."
+    "HASURA-GRAPHQL-JWT-SECRET"    = "JWT secret for Hasura GraphQL engine (JSON format)."
+    "STORAGE-ACCESS-KEY"           = "Access key for Azure Blob Storage HMAC or MinIO."
+    "STORAGE-SECRET-KEY"           = "Secret key for Azure Blob Storage HMAC or MinIO."
+    "OPENAI-API-KEY"               = "API key for OpenAI services."
+    "BASIC-AUTH-FUNCTIONS-ADMIN"   = "Basic authentication credentials for -admin endpoints in functions service."
+    "GOOGLE-CLIENT-ID-ATOMIC-WEB"  = "Google Client ID for Atomic Web application."
+    "ZOOM-CLIENT-SECRET"           = "Zoom Client Secret."
+    "TRAEFIK-USER"                 = "Username for Traefik dashboard basic authentication."
+    "TRAEFIK-PASSWORD"             = "Password for Traefik dashboard basic authentication."
+    "GOOGLE-CLIENT-ID-ANDROID"     = "Google Client ID for Android application."
+    "GOOGLE-CLIENT-ID-IOS"         = "Google Client ID for iOS application."
+    "GOOGLE-CLIENT-SECRET-ATOMIC-WEB" = "Google Client Secret for Atomic Web application."
+    "GOOGLE-CLIENT-SECRET-WEB"     = "Google Client Secret for Web application."
+    "KAFKA-USERNAME"               = "Username for Kafka SASL authentication."
+    "KAFKA-PASSWORD"               = "Password for Kafka SASL authentication."
+    "OPENSEARCH-USERNAME"          = "Username for OpenSearch security."
+    "OPENSEARCH-PASSWORD"          = "Password for OpenSearch security."
+    "ZOOM-PASS-KEY"                = "Zoom Pass Key for encryption."
+    "ZOOM-CLIENT-ID"               = "Zoom Client ID."
+    "ZOOM-SALT-FOR-PASS"           = "Zoom Salt for Pass Key."
+    "ZOOM-IV-FOR-PASS"             = "Zoom IV for Pass Key."
+    "ZOOM-WEBHOOK-SECRET-TOKEN"    = "Zoom Webhook Secret Token."
+    "API-TOKEN"                    = "General API Token for custom services."
+  }
+}
+
+# --- PostgreSQL Flexible Server Configuration Variables ---
+variable "pg_server_name_suffix" {
+  description = "A suffix for the PostgreSQL Flexible Server name. Full name will be <project_name>-pgs-<suffix>."
+  type        = string
+  default     = "pgs01"
+}
+
+variable "pg_admin_username" {
+  description = "Administrator username for the PostgreSQL Flexible Server."
+  type        = string
+  default     = "pgatomicadmin"
+}
+
+variable "pg_sku_name" {
+  description = "SKU name for the PostgreSQL Flexible Server (e.g., GP_Standard_D2s_v3, B_Standard_B1ms)."
+  type        = string
+  default     = "B_Standard_B1ms"
+}
+
+variable "pg_version" {
+  description = "PostgreSQL major version (e.g., 13, 14, 15, 16)."
+  type        = string
+  default     = "14"
+}
+
+variable "pg_storage_mb" {
+  description = "Storage size in MB for the PostgreSQL Flexible Server."
+  type        = number
+  default     = 32768 # 32 GB
+}
+
+variable "pg_backup_retention_days" {
+  description = "Backup retention period in days."
+  type        = number
+  default     = 7
+}
+
+variable "pg_geo_redundant_backup_enabled" {
+  description = "Enable geo-redundant backups for PostgreSQL."
+  type        = bool
+  default     = false
+}
+
+variable "pg_initial_database_name" {
+  description = "The name of the initial database to be created on the PostgreSQL server."
+  type        = string
+  default     = "atomicdb"
+}
+
+variable "pg_admin_password_secret_name_in_kv" { # Renamed for clarity
+  description = "The name of the secret in Azure Key Vault that stores the PostgreSQL admin password."
+  type        = string
+  default     = "POSTGRES-PASSWORD" # Must match a key in secrets_to_create_in_kv
+}
+
+# --- Managed Identity Configuration Variables ---
+variable "aks_kubelet_mi_name_suffix" {
+  description = "Suffix for the User-Assigned Managed Identity for AKS Kubelet."
+  type        = string
+  default     = "aks-kubelet-mi"
+}
+
+# IDs for linking resources (these will be outputs from other resources, not direct user inputs in a monolithic setup)
+# For a modular setup, these would be actual input variables.
+# For this flat structure, they are effectively local references.
+# To make this variables.tf self-contained for potential modular use, they are defined.
+# However, their defaults would typically not be set or would be `null`.
+# For now, leaving them without defaults as they are meant to be dynamically populated.
+
+variable "aks_subnet_id_input" { # Used by aks_cluster.tf
+  description = "The ID of the subnet where AKS nodes will be deployed. (Typically output from vnet.tf)"
+  type        = string
+  default = null # No default, must be provided or derived from azurerm_subnet.aks.id
+}
+
+variable "db_subnet_id_input" { # Used by postgresql.tf
+  description = "The ID of the subnet to which the PostgreSQL Flexible Server should be delegated. (Typically output from vnet.tf)"
+  type        = string
+  default = null
+}
+
+variable "vnet_id_for_dns_link_input" { # Used by postgresql.tf
+  description = "The ID of the Virtual Network to link with the Private DNS Zone for PostgreSQL. (Typically output from vnet.tf)"
+  type        = string
+  default = null
+}
+
+variable "key_vault_id_for_pg_password_input" { # Used by postgresql.tf
+  description = "The ID of the Azure Key Vault where the PostgreSQL admin password secret is stored. (Typically output from key_vault.tf)"
+  type        = string
+  default = null
+}
+
+variable "aks_cluster_system_assigned_identity_principal_id_input" { # Used by acr.tf
+  description = "The Principal ID of the System Assigned Managed Identity of the AKS cluster. Used for granting AcrPull role. (Typically output from aks_cluster.tf)"
+  type        = string
+  default = null
+}
+
+variable "acr_id_for_mi_assignment_input" { # Used by managed_identity.tf
+  description = "The ID of the Azure Container Registry for AcrPull role assignment to Kubelet MI. (Typically output from acr.tf)"
+  type        = string
+  default = null
+}
+
+variable "key_vault_id_for_mi_assignment_input" { # Used by managed_identity.tf
+  description = "The ID of the Azure Key Vault for Key Vault Secrets User role assignment to Kubelet MI. (Typically output from key_vault.tf)"
+  type        = string
+  default = null
+}
+
+variable "aks_kubelet_mi_object_id_input" { # Used by key_vault.tf (as aks_secret_accessor_identity_object_id)
+  description = "The Object ID of the User-Assigned Managed Identity for Kubelet (or other MI for KV access). (Typically output from managed_identity.tf)"
+  type        = string
+  default = null
+}
+
+
+# --- Data Sources ---
+# To get current tenant_id if not explicitly provided by var.tenant_id
+data "azurerm_client_config" "current" {}
+
+# Resource for generating random strings for globally unique names
+resource "random_string" "global_suffix" {
+  length  = 6
+  special = false
+  upper   = false
+}

--- a/deploy/azure/terraform/versions.tf
+++ b/deploy/azure/terraform/versions.tf
@@ -1,0 +1,56 @@
+# Terraform Version and Backend Configuration
+
+terraform {
+  # Specifies the minimum version of Terraform that can be used with this configuration.
+  # It's recommended to set this to ensure compatibility with Terraform features and syntax used.
+  required_version = ">= 1.3.0" # Example: requires Terraform version 1.3.0 or later
+
+  # --- Terraform Backend Configuration (Azure Blob Storage Example - CRITICAL FOR PRODUCTION) ---
+  # The backend configuration defines where Terraform stores its state data.
+  # Using a remote backend like Azure Blob Storage is highly recommended for any
+  # collaborative or production environment for several reasons:
+  #   - State Locking: Prevents multiple users or automation processes from concurrently
+  #     modifying the state, which can lead to corruption. Azure Blob Storage uses blob leases for locking.
+  #   - Shared State: Allows team members and CI/CD systems to access and modify the same infrastructure state.
+  #   - Durability & Availability: Leverages Azure Blob Storage's high durability and availability.
+  #   - Versioning: Blob versioning can be enabled on the storage account to keep a history of state changes.
+  #   - Security: Access to the state data can be controlled using Azure RBAC and storage account keys/SAS tokens.
+  #
+  # To use this Azure Blob Storage backend:
+  #   1. Create an Azure Storage Account (e.g., "yourprojecttfstate").
+  #   2. Create a Blob Container within that storage account (e.g., "terraform-state").
+  #   3. Ensure the identity running `terraform init` (user, service principal, or managed identity) has:
+  #      - "Storage Blob Data Contributor" or "Storage Blob Data Owner" role on the container (or storage account).
+  #      - Permissions to create leases on blobs for state locking.
+  #   4. Uncomment the block below and replace the placeholder values with your actual
+  #      storage account name, container name, and state file key (path).
+  #   5. Run `terraform init`. Terraform will prompt you to copy existing local state (if any)
+  #      to the new Azure Blob Storage backend.
+
+  /*
+  backend "azurerm" {
+    resource_group_name  = "your-terraform-state-rg"       # Name of the resource group containing the storage account
+    storage_account_name = "yourtfstatesaccountunique"     # Name of the storage account (globally unique)
+    container_name       = "tfstate"                       # Name of the blob container
+    key                  = "azure/${var.project_name}/${var.environment_name}/terraform.tfstate" # Path to the state file in the container
+    # Optional: Specify if using a specific access key (not recommended for most scenarios, prefer identity-based auth)
+    # access_key         = "YOUR_STORAGE_ACCOUNT_ACCESS_KEY"
+
+    # Optional: For using MSI (Managed Service Identity) or Service Principal authentication for the backend
+    # use_msi = true # if running Terraform from an Azure resource with MSI
+    # subscription_id = "YOUR_AZURE_SUBSCRIPTION_ID"
+    # tenant_id       = "YOUR_AZURE_TENANT_ID"
+    # client_id       = "YOUR_SP_CLIENT_ID"       # If using Service Principal
+    # client_secret   = "YOUR_SP_CLIENT_SECRET"   # If using Service Principal (store securely!)
+  }
+  */
+}
+
+# Note on using variables in backend configuration:
+# Variables like var.project_name and var.environment_name in the `key` attribute provide flexibility.
+# However, these variables must be available at `terraform init` time. This can be achieved by:
+# 1. Using partial configuration: `terraform init -backend-config="key=azure/myproject/dev/terraform.tfstate"`
+# 2. Using a backend configuration file: `terraform init -backend-config=backend-dev.conf`
+#    (where backend-dev.conf contains the key, storage_account_name, etc.)
+# For simpler setups, you might hardcode parts of the key or use a fixed key name per environment.
+# Using a consistent naming convention for the state file key is important for organization.

--- a/deploy/azure/terraform/vnet.tf
+++ b/deploy/azure/terraform/vnet.tf
@@ -1,0 +1,202 @@
+# --- Variables ---
+variable "azure_region" {
+  description = "The Azure region where the VNet and subnets will be created."
+  type        = string
+}
+
+variable "resource_group_name" {
+  description = "The name of the Azure Resource Group where resources will be deployed."
+  type        = string
+}
+
+variable "project_name" {
+  description = "Name of the project, used for tagging and naming resources."
+  type        = string
+}
+
+variable "vnet_cidr" {
+  description = "The CIDR block for the Azure Virtual Network."
+  type        = string
+  default     = "10.1.0.0/16" # Example CIDR for the VNet
+}
+
+variable "aks_subnet_cidr" {
+  description = "The CIDR block for the AKS subnet."
+  type        = string
+  default     = "10.1.1.0/24" # Example CIDR for AKS subnet
+}
+
+variable "application_subnet_cidr" {
+  description = "The CIDR block for the general application subnet."
+  type        = string
+  default     = "10.1.2.0/24" # Example CIDR for application subnet
+}
+
+variable "database_subnet_cidr" {
+  description = "The CIDR block for the database subnet."
+  type        = string
+  default     = "10.1.3.0/24" # Example CIDR for database subnet
+}
+
+# --- Virtual Network (VNet) ---
+resource "azurerm_virtual_network" "main" {
+  name                = "${var.project_name}-vnet"
+  address_space       = [var.vnet_cidr]
+  location            = var.azure_region
+  resource_group_name = var.resource_group_name
+
+  tags = {
+    environment = "Production" # Or as per your tagging strategy
+    project     = var.project_name
+    terraform   = "true"
+  }
+}
+
+# --- Subnets ---
+
+# AKS Subnet
+resource "azurerm_subnet" "aks" {
+  name                 = "${var.project_name}-aks-subnet"
+  resource_group_name  = var.resource_group_name
+  virtual_network_name = azurerm_virtual_network.main.name
+  address_prefixes     = [var.aks_subnet_cidr]
+
+  # No specific service endpoints or delegations needed for a basic AKS subnet usually,
+  # unless specific integrations require them (e.g., Azure Container Instances).
+  # AKS itself will configure network properties as needed, especially with Azure CNI.
+  # If using Azure CNI, AKS might also create/manage an NSG on the NICs in this subnet.
+  # An NSG can be associated with this subnet via `azurerm_subnet_network_security_group_association`.
+
+  tags = {
+    Name      = "${var.project_name}-aks-subnet"
+    Purpose   = "AKS Nodes and Pods"
+    Project   = var.project_name
+    Terraform = "true"
+  }
+}
+
+# Application Subnet (for other VMs, App Service Environment, etc. - if needed)
+# For this project, most applications run within AKS.
+# This subnet is included for completeness if other non-AKS apps or services need VNet integration.
+resource "azurerm_subnet" "application" {
+  name                 = "${var.project_name}-app-subnet"
+  resource_group_name  = var.resource_group_name
+  virtual_network_name = azurerm_virtual_network.main.name
+  address_prefixes     = [var.application_subnet_cidr]
+
+  tags = {
+    Name      = "${var.project_name}-app-subnet"
+    Purpose   = "General Application Services"
+    Project   = var.project_name
+    Terraform = "true"
+  }
+}
+
+# Database Subnet (for Azure Database for PostgreSQL, SQL Managed Instance, etc.)
+resource "azurerm_subnet" "database" {
+  name                 = "${var.project_name}-db-subnet"
+  resource_group_name  = var.resource_group_name
+  virtual_network_name = azurerm_virtual_network.main.name
+  address_prefixes     = [var.database_subnet_cidr]
+
+  # Service Endpoints allow PaaS services like Azure SQL, Azure Storage to be secured to your VNet.
+  # "Microsoft.Sql" is for Azure SQL Database, SQL Managed Instance, and Azure Database for PostgreSQL (server, not flexible server usually).
+  # For Azure Database for PostgreSQL Flexible Server, Private Endpoints are more common.
+  service_endpoints = ["Microsoft.Sql"] # Enables direct VNet integration for supported SQL services.
+
+  # If using Private Endpoints for Azure Database for PostgreSQL Flexible Server (recommended),
+  # you might need to disable network policies on the subnet for the private endpoint.
+  # This is typically done on the subnet where the *private endpoint* is created, which might be this DB subnet or another.
+  # private_endpoint_network_policies_enabled = false # Set to false if Private Endpoints will be deployed into this subnet.
+                                                    # Default is true. Check Azure provider docs for exact resource.
+                                                    # This is on `azurerm_subnet.private_endpoint_subnet_enforce_private_link_endpoint_network_policies`
+                                                    # or `azurerm_subnet.private_endpoint_subnet_enforce_private_link_service_network_policies`
+
+  # Delegations (e.g., for Azure Database for PostgreSQL Flexible Server if deployed directly into a delegated subnet)
+  # delegation {
+  #   name = "Microsoft.DBforPostgreSQL.flexibleServers"
+  #   service_delegation {
+  #     name    = "Microsoft.DBforPostgreSQL/flexibleServers"
+  #     actions = ["Microsoft.Network/virtualNetworks/subnets/join/action"]
+  #   }
+  # }
+
+  tags = {
+    Name      = "${var.project_name}-db-subnet"
+    Purpose   = "Database Services"
+    Project   = var.project_name
+    Terraform = "true"
+  }
+}
+
+# --- (Optional) Route Table Example ---
+# By default, subnets use the system route table for the VNet, which allows communication
+# between all subnets in the VNet and uses default Azure routing for outbound traffic.
+# If custom routing is needed (e.g., to a Network Virtual Appliance (NVA) for internet traffic,
+# or specific routes to on-premises networks via VPN/ExpressRoute), you would define a route table
+# and associate it with subnets.
+
+/*
+resource "azurerm_route_table" "main_rt" {
+  name                          = "${var.project_name}-main-rt"
+  location                      = var.azure_region
+  resource_group_name           = var.resource_group_name
+  disable_bgp_route_propagation = false # Set to true if using BGP with ExpressRoute/VPN and want to control routes manually
+
+  route {
+    name           = "DefaultToInternetViaNVA" # Example route
+    address_prefix = "0.0.0.0/0"
+    next_hop_type  = "VirtualAppliance"
+    next_hop_in_ip_address = "IP_ADDRESS_OF_YOUR_NVA" # IP address of your firewall/NVA
+  }
+
+  tags = {
+    Name      = "${var.project_name}-main-rt"
+    Project   = var.project_name
+    Terraform = "true"
+  }
+}
+
+# Example association (e.g., for the application subnet)
+resource "azurerm_subnet_route_table_association" "application_subnet_rt_assoc" {
+  subnet_id      = azurerm_subnet.application.id
+  route_table_id = azurerm_route_table.main_rt.id
+}
+*/
+
+# --- Outputs (typically in outputs.tf) ---
+# Moved to outputs.tf as per best practice.
+# output "vnet_id" {
+#   description = "The ID of the created Azure Virtual Network."
+#   value       = azurerm_virtual_network.main.id
+# }
+#
+# output "vnet_name" {
+#   description = "The name of the created Azure Virtual Network."
+#   value       = azurerm_virtual_network.main.name
+# }
+#
+# output "aks_subnet_id" {
+#   description = "The ID of the AKS subnet."
+#   value       = azurerm_subnet.aks.id
+# }
+#
+# output "application_subnet_id" {
+#   description = "The ID of the application subnet."
+#   value       = azurerm_subnet.application.id
+# }
+#
+# output "database_subnet_id" {
+#   description = "The ID of the database subnet."
+#   value       = azurerm_subnet.database.id
+# }
+#
+# output "database_subnet_address_prefix" { # Useful for NSG rules on other subnets
+#   description = "The address prefix of the database subnet."
+#   value       = azurerm_subnet.database.address_prefixes[0]
+# }
+#
+# output "aks_subnet_address_prefix" { # Useful for NSG rules on other subnets
+#   description = "The address prefix of the AKS subnet."
+#   value       = azurerm_subnet.aks.address_prefixes[0]
+# }

--- a/deploy/kubernetes/overlays/azure/kustomization.yaml
+++ b/deploy/kubernetes/overlays/azure/kustomization.yaml
@@ -1,11 +1,12 @@
 # deploy/kubernetes/overlays/azure/kustomization.yaml
 # This Kustomization file defines the Azure-specific overlay for the Kubernetes deployment.
-# It builds upon the 'base' configuration and applies Azure-specific resources and patches.
+# It builds upon the 'base' configuration and applies Azure-specific resources, patches, and image overrides.
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 # 1. Include the base configuration
+# This brings in all the common Kubernetes manifests defined in the base layer.
 bases:
   - ../../base # Points to deploy/kubernetes/base
 
@@ -15,11 +16,10 @@ resources:
   - resources/secret-provider-classes-azure.yaml
 
 # 3. List patches to apply to the base resources for the Azure environment.
-#    Using patchesStrategicMerge for broad compatibility.
-#    For Kustomize v4+, `patches:` can also be used for plain YAML patches.
+#    These patches customize base resources for Azure-specific needs.
 patchesStrategicMerge:
   # Patch to update secret references in Deployments/StatefulSets to use
-  # Kubernetes Secrets created by SecretProviderClasses that source from Azure Key Vault.
+  # Kubernetes Secrets created by SecretProviderClasses (sourcing from Azure Key Vault).
   - patches/update-secret-references-azure.yaml
 
   # Patch to add Azure Load Balancer specific annotations to the Traefik service.
@@ -30,28 +30,43 @@ patchesStrategicMerge:
   # or patches to configure Azure-specific storage options for PersistentVolumeClaims.
   # - patches/serviceaccount-workload-identity-annotations.yaml
   # - patches/pvc-azure-storage-config.yaml
-  #
-  # Example for Workload Identity (serviceaccount-workload-identity-annotations.yaml):
-  #   apiVersion: v1
-  #   kind: ServiceAccount
-  #   metadata:
-  #     name: <service-account-name>
-  #     namespace: <namespace>
-  #     annotations:
-  #       azure.workload.identity/client-id: "YOUR_AZURE_AD_APP_CLIENT_ID"
-  #       azure.workload.identity/tenant-id: "YOUR_AZURE_TENANT_ID"
-  #     labels: # Required for webhook to inject details
-  #       azure.workload.identity/use: "true"
 
+# 4. Image Overrides for Azure Container Registry (ACR)
+# This section overrides placeholder image names used in the base manifests
+# with actual ACR repository URIs for the Azure environment.
+# Replace YOUR_ACR_LOGIN_SERVER (e.g., myatomicacr.azurecr.io) and
+# YOUR_PROJECT_NAME_PREFIX (e.g., atomic if your images in ACR are named like atomic/atomic-functions)
+# with your actual values. The image tag (e.g., 'latest' or a specific version) should also be set as appropriate.
+# The Terraform acr.tf created repositories like "${var.project_name}-${each.key}", e.g., "atomic-atomic-functions".
+# So, the image name in ACR would be "atomic-atomic-functions" if project_name is "atomic".
+# Or, if you push to ACR with a simpler name like "atomic-functions", adjust accordingly.
+# Assuming image names in ACR are PROJECT_NAME_FROM_TF/SERVICE_NAME_SUFFIX or just SERVICE_NAME_SUFFIX if PROJECT_NAME_FROM_TF is part of login server or implicit.
+# Let's use a common pattern: YOUR_ACR_LOGIN_SERVER/YOUR_PROJECT_NAME_FROM_TF/atomic-<service_suffix> or YOUR_ACR_LOGIN_SERVER/atomic-<service_suffix>
+# The TF for ACR names them like: ${var.project_name}-${image_name_suffix} e.g. atomic-atomic-scheduler.
+images:
+  - name: placeholder-atomic-scheduler # Base name for Optaplanner image
+    # Example: myacr.azurecr.io/atomic-atomic-scheduler
+    newName: YOUR_ACR_LOGIN_SERVER/YOUR_PROJECT_NAME_FROM_TF-atomic-scheduler
+    newTag: latest # Or a specific Git SHA, version tag, etc.
 
-# Images: Overlays can also be used to update image tags or registries for Azure Container Registry (ACR).
-# Example:
-# images:
-#   - name: placeholder-image-name # As defined in the base deployment
-#     newName: youracreg.azurecr.io/imagename # New image URI for ACR
-#     newTag: specific-tag-for-azure # New image tag for Azure
+  - name: placeholder-atomic-functions # Base name for Functions service image
+    newName: YOUR_ACR_LOGIN_SERVER/YOUR_PROJECT_NAME_FROM_TF-atomic-functions
+    newTag: latest
+
+  - name: placeholder-atomic-handshake # Base name for Handshake service image
+    newName: YOUR_ACR_LOGIN_SERVER/YOUR_PROJECT_NAME_FROM_TF-atomic-handshake
+    newTag: latest
+
+  - name: placeholder-atomic-oauth # Base name for OAuth service image
+    newName: YOUR_ACR_LOGIN_SERVER/YOUR_PROJECT_NAME_FROM_TF-atomic-oauth
+    newTag: latest
+
+  - name: placeholder-atomic-app # Base name for App (frontend) service image
+    newName: YOUR_ACR_LOGIN_SERVER/YOUR_PROJECT_NAME_FROM_TF-atomic-app
+    newTag: latest
 
 # Common Labels or Annotations for this overlay (optional)
+# These would apply to all resources defined or included by this kustomization if uncommented.
 # commonLabels:
 #   cloud-provider: azure
 #   overlay: azure-specific

--- a/deploy/kubernetes/overlays/azure/patches/traefik-service-azure-annotations.yaml
+++ b/deploy/kubernetes/overlays/azure/patches/traefik-service-azure-annotations.yaml
@@ -1,6 +1,7 @@
 # deploy/kubernetes/overlays/azure/patches/traefik-service-azure-annotations.yaml
 # This patch adds Azure Load Balancer specific annotations to the Traefik service.
-# It assumes the base Traefik service is named 'traefik' and is in the 'traefik-ingress' namespace.
+# It assumes the base Traefik service is named 'traefik' and is in the 'traefik-ingress' namespace,
+# and is of type LoadBalancer.
 
 apiVersion: v1
 kind: Service
@@ -10,62 +11,56 @@ metadata:
   annotations:
     # --- Azure Load Balancer Configuration Annotations ---
 
-    # Specify the SKU for the Azure Load Balancer (Standard is recommended for production)
-    # Basic SKU does not support certain features like availability zones, multiple frontends, or health probes on specific paths.
+    # Specify the SKU for the Azure Load Balancer. "Standard" is recommended for production.
+    # "Basic" SKU has limitations (e.g., no availability zones, no health probes on specific paths).
     service.beta.kubernetes.io/azure-load-balancer-sku: "Standard"
 
-    # Specify if the load balancer is internet-facing or internal
-    # "false" means internet-facing. "true" would make it internal.
+    # Specify if the load balancer is internet-facing or internal.
+    # "false" means internet-facing (public). "true" would make it internal.
     service.beta.kubernetes.io/azure-load-balancer-internal: "false"
 
     # --- Health Probe Configuration ---
-    # Define the request path for the health probe. Traefik has a /ping endpoint.
+    # Define the request path for the health probe. Traefik typically has a /ping endpoint for health checks.
     service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: "/ping"
 
     # Specify which port on the service the health probe should target.
     # This should be the port number that corresponds to a Traefik entrypoint where /ping is available.
-    # If Traefik's service exposes a port named 'web' (typically port 80) and /ping is accessible there:
-    # service.beta.kubernetes.io/azure-load-balancer-health-probe-port: "80"
-    # Or if the port is named 'traefik' (dashboard/api, typically 8080) and /ping is there:
-    # service.beta.kubernetes.io/azure-load-balancer-health-probe-port: "8080"
-    # For this example, let's assume the 'web' entrypoint (port 80) serves /ping.
-    # Ensure the base Traefik service spec.ports has a port that will eventually map to container port 80.
-    # If the service port is named 'web', you can often just let it default or match.
-    # The actual port number is safer.
-    service.beta.kubernetes.io/azure-load-balancer-health-probe-port: "80" # Assuming /ping is on port 80 of Traefik
+    # Assuming Traefik's 'web' entrypoint (port 80) also serves the /ping endpoint for LB health checks.
+    service.beta.kubernetes.io/azure-load-balancer-health-probe-port: "80"
 
-    # Interval in seconds for health probe (e.g., 5, 15, 30)
-    # service.beta.kubernetes.io/azure-load-balancer-health-probe-interval: "15"
-
-    # Number of consecutive successful probes to mark the backend healthy
-    # service.beta.kubernetes.io/azure-load-balancer-health-probe-num-of-probes: "2"
-
-    # --- Optional: Idle Timeout ---
-    # Configure the idle timeout for TCP connections, in minutes. Default is 4 minutes. Max is 30.
+    # --- Idle Timeout Configuration ---
+    # Configure the idle timeout for TCP and HTTP connections, in minutes. Default is 4 minutes. Max is 30.
     service.beta.kubernetes.io/azure-load-balancer-idle-timeout-in-minutes: "30"
 
     # --- Optional: Use a pre-existing Public IP Address ---
-    # If you have a static public IP address created in Azure that you want to assign to the Load Balancer.
+    # If you have a static public IP address resource created in Azure that you want to assign to the Load Balancer.
+    # The Public IP must be of the same SKU (Standard) and in the same region as the AKS cluster.
+    #
     # 1. Name of the Public IP Address resource in Azure:
     # service.beta.kubernetes.io/azure-pip-name: "your-existing-public-ip-name"
     #
-    # 2. Resource group of the Public IP Address (if different from the cluster's node resource group):
-    # service.beta.kubernetes.io/azure- öffentliche-ip-adresse-resource-gruppe: "your-public-ip-resource-group"
-    # (Note: the annotation key for public IP resource group might vary or might not be needed if in same RG as cluster nodes)
-    # A common one is `service.beta.kubernetes.io/azure-load-balancer-resource-group` for the LB itself,
-    # and `service.beta.kubernetes.io/azure-dns-label-name` for a DNS label.
-    # For public IP, `azure-pip-name` is standard. If it's in a different RG, it's more complex.
-    # Usually, the public IP is expected to be in the same RG as the cluster for auto-association.
+    # 2. Resource group of the Public IP Address (if different from the cluster's node resource group - MC_*):
+    #    Typically, for auto-association, it's expected to be in the node resource group or explicitly specified.
+    # service.beta.kubernetes.io/azure-load-balancer-resource-group: "your-public-ip-resource-group"
+    # (More commonly, the public IP is created in the node resource group if managed by AKS LB integration)
 
-    # --- Optional: DNS Label ---
-    # Creates a DNS A record (e.g., mytraefik.eastus.cloudapp.azure.com)
+    # --- Optional: DNS Label Name ---
+    # Creates a DNS A record for the Load Balancer's public IP (e.g., mytraefik.eastus.cloudapp.azure.com).
+    # The DNS label must be unique within its Azure region.
     # service.beta.kubernetes.io/azure-dns-label-name: "your-traefik-dns-label"
 
     # --- Optional: Enable PROXY protocol (v2) ---
     # If Traefik is configured to use PROXY protocol to receive client IP information.
+    # Both Traefik and the Azure LB need to be configured for this.
     # service.beta.kubernetes.io/azure-load-balancer-enable-proxy-protocol: "true"
+
+    # --- Optional: Specify number of health probe retries ---
+    # service.beta.kubernetes.io/azure-load-balancer-health-probe-num-of-probes: "2" # Default is 2
+
+    # --- Optional: Specify health probe interval ---
+    # service.beta.kubernetes.io/azure-load-balancer-health-probe-interval: "5" # Default is 5 seconds
 
     # Note: Ensure the Kubernetes cloud provider integration with Azure is correctly configured
     # in your AKS cluster for these annotations to take effect.
     # The specific annotations available and their behavior can depend on the version
-    # of the Kubernetes Azure cloud provider. Always refer to its official documentation.
+    # of the Kubernetes Azure cloud provider and AKS. Always refer to official Azure Kubernetes Service (AKS) documentation.

--- a/deploy/kubernetes/overlays/azure/patches/update-secret-references-azure.yaml
+++ b/deploy/kubernetes/overlays/azure/patches/update-secret-references-azure.yaml
@@ -1,9 +1,10 @@
 # deploy/kubernetes/overlays/azure/patches/update-secret-references-azure.yaml
 # This file contains strategic merge patches to update secret references
-# for the Azure overlay, pointing to secrets synced by SecretProviderClasses from Azure Key Vault.
+# for the Azure overlay, pointing to Kubernetes Secrets synced by SecretProviderClasses
+# from Azure Key Vault.
 
 # --- Patch for Functions Deployment ---
-# Base 'functions-secret' -> SPC 'functions-app-credentials-azure'
+# Base 'functions-secret' -> New 'functions-app-credentials-azure'
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -13,15 +14,15 @@ spec:
   template:
     spec:
       containers:
-      - name: functions
-        envFrom: # Replaces the existing envFrom array
+      - name: functions # Assuming the container is named 'functions'
+        envFrom: # This replaces the entire envFrom array for this container
           - secretRef:
-              name: functions-app-credentials-azure # Patched
+              name: functions-app-credentials-azure # Patched: points to SPC-synced K8s Secret
           - configMapRef: # Must re-state if present in base
               name: functions-configmap
 
 # --- Patch for App Deployment ---
-# Base 'app-secret' -> SPC 'app-credentials-azure'
+# Base 'app-secret' -> New 'app-credentials-azure'
 # This patches both the 'envFrom' and specific 'env' vars that referenced 'app-secret'.
 apiVersion: apps/v1
 kind: Deployment
@@ -32,18 +33,18 @@ spec:
   template:
     spec:
       containers:
-      - name: app
+      - name: app # Assuming the container is named 'app'
         envFrom: # Replaces the 'envFrom' part
           - secretRef:
               name: app-credentials-azure # Patched
           - configMapRef:
               name: app-configmap
-        env: # Attempts to merge/replace individual env vars by name
+        env: # Attempts to merge/replace individual env vars by name that were from app-secret
           - name: HASURA_GRAPHQL_ADMIN_SECRET
             valueFrom:
               secretKeyRef:
                 name: app-credentials-azure # Patched
-                key: HASURA_GRAPHQL_ADMIN_SECRET
+                key: HASURA_GRAPHQL_ADMIN_SECRET # Key in the new K8s Secret
           - name: GOOGLE_CLIENT_ID_ATOMIC_WEB
             valueFrom:
               secretKeyRef:
@@ -64,9 +65,10 @@ spec:
               secretKeyRef:
                 name: app-credentials-azure # Patched
                 key: ZOOM_PASS_KEY
+          # Other env vars from base, not listed here, should remain untouched by this 'env:' block.
 
 # --- Patch for Handshake Deployment ---
-# Base 'handshake-secret' -> SPC 'handshake-credentials-azure'
+# Base 'handshake-secret' -> New 'handshake-credentials-azure'
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -84,7 +86,7 @@ spec:
               name: handshake-configmap
 
 # --- Patch for OAuth Deployment ---
-# Base 'oauth-secret' -> SPC 'oauth-credentials-azure'
+# Base 'oauth-secret' -> New 'oauth-credentials-azure'
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -102,7 +104,7 @@ spec:
               name: oauth-configmap
 
 # --- Patch for PostgreSQL StatefulSet ---
-# Base 'postgres-secret' -> SPC 'postgres-credentials-azure'
+# Base 'postgres-secret' -> New 'postgres-credentials-azure'
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -118,16 +120,18 @@ spec:
           valueFrom:
             secretKeyRef:
               name: postgres-credentials-azure # Patched
-              key: POSTGRES_USER
+              key: POSTGRES_USER # Key in the new K8s Secret
         - name: POSTGRES_PASSWORD
           valueFrom:
             secretKeyRef:
               name: postgres-credentials-azure # Patched
-              key: POSTGRES_PASSWORD
+              key: POSTGRES_PASSWORD # Key in the new K8s Secret
+        # Other env vars like POSTGRES_DB and PGDATA from base are direct values, not from secret.
 
 # --- Patch for MinIO Deployment ---
-# Base 'minio-secret' -> SPC 'minio-credentials-azure'
-# Keys in minio-credentials-azure are MINIO_ROOT_USER, MINIO_ROOT_PASSWORD (mapped from KV STORAGE-ACCESS-KEY etc.)
+# Base 'minio-secret' -> New 'minio-credentials-azure'
+# Keys in minio-credentials-azure are MINIO_ROOT_USER, MINIO_ROOT_PASSWORD
+# (as mapped in the SecretProviderClass from Azure Key Vault STORAGE-ACCESS-KEY etc.)
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -143,15 +147,15 @@ spec:
           valueFrom:
             secretKeyRef:
               name: minio-credentials-azure # Patched
-              key: MINIO_ROOT_USER
+              key: MINIO_ROOT_USER # This key is defined in the SecretProviderClass.secretObjects.data mapping
         - name: MINIO_ROOT_PASSWORD
           valueFrom:
             secretKeyRef:
               name: minio-credentials-azure # Patched
-              key: MINIO_ROOT_PASSWORD
+              key: MINIO_ROOT_PASSWORD # This key is defined in the SecretProviderClass.secretObjects.data mapping
 
 # --- Patch for Supertokens Deployment ---
-# Base 'supertokens-db-secret' -> SPC 'supertokens-db-credentials-azure'
+# Base 'supertokens-db-secret' -> New 'supertokens-db-credentials-azure'
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -173,25 +177,25 @@ spec:
             secretKeyRef:
               name: supertokens-db-credentials-azure # Patched
               key: DB_PASSWORD # Key in the K8s Secret (from KV objectName POSTGRES-PASSWORD)
-        - name: POSTGRESQL_HOST
+        - name: POSTGRESQL_HOST # Base manifest for supertokens sourced these from its 'supertokens-db-secret'
           valueFrom:
             secretKeyRef:
               name: supertokens-db-credentials-azure # Patched
-              key: DB_HOST # Assuming DB_HOST is also in this synced secret if needed, or it's from ConfigMap
-                           # Base supertokens manifest sourced all DB parts from secret.
+              key: DB_HOST
         - name: POSTGRESQL_PORT
           valueFrom:
             secretKeyRef:
-              name: supertokens-db-credentials-azure
+              name: supertokens-db-credentials-azure # Patched
               key: DB_PORT
         - name: POSTGRESQL_DATABASE_NAME
           valueFrom:
             secretKeyRef:
-              name: supertokens-db-credentials-azure
+              name: supertokens-db-credentials-azure # Patched
               key: DB_NAME
+        # POSTGRESQL_TABLE_NAMES_PREFIX was a direct value, unaffected.
 
 # --- Patch for Hasura Deployment ---
-# Base 'hasura-secret' -> SPC 'hasura-credentials-azure'
+# Base 'hasura-secret' -> New 'hasura-credentials-azure'
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -203,6 +207,8 @@ spec:
       containers:
       - name: hasura
         env:
+        # HASURA_GRAPHQL_DATABASE_URL value is "postgres://$(DB_USER):$(DB_PASSWORD)@$(DB_HOST):$(DB_PORT)/$(DB_NAME)"
+        # We patch the sources of these $(...) variables.
         - name: DB_USER
           valueFrom:
             secretKeyRef:
@@ -238,9 +244,10 @@ spec:
             secretKeyRef:
               name: hasura-credentials-azure # Patched
               key: HASURA_GRAPHQL_ADMIN_SECRET
+        # Other direct value env vars (HASURA_GRAPHQL_UNAUTHORIZED_ROLE, etc.) are unaffected.
 
 # --- Patch for Optaplanner Deployment ---
-# Base 'optaplanner-secret' -> SPC 'optaplanner-credentials-azure'
+# Base 'optaplanner-secret' -> New 'optaplanner-credentials-azure'
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -267,3 +274,4 @@ spec:
             secretKeyRef:
               name: optaplanner-credentials-azure # Patched
               key: API_TOKEN # Key in K8s Secret (from KV objectName API-TOKEN)
+        # Other env vars from ConfigMap or direct value are unaffected.

--- a/deploy/kubernetes/overlays/azure/resources/secret-provider-classes-azure.yaml
+++ b/deploy/kubernetes/overlays/azure/resources/secret-provider-classes-azure.yaml
@@ -1,34 +1,53 @@
 # deploy/kubernetes/overlays/azure/resources/secret-provider-classes-azure.yaml
+# This file defines SecretProviderClass resources for integrating Azure Key Vault
+# with Kubernetes workloads using the Secrets Store CSI Driver.
+
+# --- Prerequisites ---
+# 1. Azure Key Vault Provider for Secrets Store CSI Driver must be enabled in your AKS cluster.
+#    (This was configured via the `azure_keyvault_secrets_provider` addon in `deploy/azure/terraform/aks_cluster.tf`).
+# 2. The Managed Identity used by the Kubelet on AKS nodes (or a specific User-Assigned MI configured for the
+#    CSI driver/pods if not using Kubelet's MI by default via the addon) must have the "Key Vault Secrets User"
+#    role assigned on the target Azure Key Vault.
+#    (This was configured in `deploy/azure/terraform/key_vault.tf` for `var.aks_secret_accessor_identity_object_id`).
+# 3. The placeholders `${KEY_VAULT_NAME}` and `${TENANT_ID}` in this file MUST be replaced with actual values
+#    during the deployment process (e.g., by a deployment script using `envsubst` or Kustomize variables/configMapGenerator).
 
 # --- SecretProviderClass for PostgreSQL Credentials (Azure) ---
 apiVersion: secrets-store.csi.x-k8s.io/v1
 kind: SecretProviderClass
 metadata:
-  name: postgres-db-creds-spc-azure
-  namespace: postgres # Target namespace for the K8s Secret
+  name: postgres-db-creds-spc-azure # Suffix '-azure' for clarity
+  namespace: postgres # Target namespace for the K8s Secret and for pods mounting this
 spec:
   provider: azure
   parameters:
-    usePodIdentity: "false" # Assumes Kubelet MI or Workload Identity for CSI driver
-    keyvaultName: "atomic-kv" # Placeholder for your Azure Key Vault name
-    tenantId: "YOUR_TENANT_ID" # Placeholder for your Azure Tenant ID
+    usePodIdentity: "false"   # Indicates not using aad-pod-identity v1.
+                              # For AKS Key Vault addon, this is typically false, relying on Kubelet MI or Workload Identity setup for the driver.
+    keyvaultName: "${KEY_VAULT_NAME}" # Placeholder: To be replaced with actual Key Vault name
+    tenantId: "${TENANT_ID}"         # Placeholder: To be replaced with actual Tenant ID
+
+    # The 'objects' parameter is a YAML string defining which secrets to fetch.
+    # objectName should be the name of the secret in Azure Key Vault.
     objects:  |
       array:
         - |
-          objectName: POSTGRES-USER # Name of the secret in Azure Key Vault
-          objectType: secret
-          # objectAlias: ALIAS_POSTGRES_USER # Optional: if you want a different filename in pod mount
+          objectName: "POSTGRES-USER" # Name of the secret in Azure Key Vault (matches key_vault.tf)
+          objectType: "secret"        # Type of object to retrieve
         - |
-          objectName: POSTGRES-PASSWORD
-          objectType: secret
-          # objectAlias: ALIAS_POSTGRES_PASSWORD
+          objectName: "POSTGRES-PASSWORD"
+          objectType: "secret"
+    # cloudName: "" # Optional: Defaults to AzurePublicCloud. Use "AzureChinaCloud", "AzureGermanCloud", "AzureUSGovernmentCloud" if needed.
+
+  # secretObjects defines Kubernetes Secret resources to be created from the fetched secrets.
   secretObjects:
     - secretName: postgres-credentials-azure # Name of the K8s Secret to create
       type: Opaque
       data:
-        - objectName: POSTGRES-USER # Corresponds to objectName in the 'objects' array above
-          key: POSTGRES_USER      # Key in the K8s Secret
-        - objectName: POSTGRES-PASSWORD
+        # 'objectName' here refers to the objectName defined in the 'parameters.objects' array above.
+        # 'key' is the key name that will be created in the Kubernetes Secret.
+        - objectName: "POSTGRES-USER"
+          key: POSTGRES_USER
+        - objectName: "POSTGRES-PASSWORD"
           key: POSTGRES_PASSWORD
 
 ---
@@ -38,30 +57,30 @@ apiVersion: secrets-store.csi.x-k8s.io/v1
 kind: SecretProviderClass
 metadata:
   name: minio-creds-spc-azure
-  namespace: minio # Target namespace for the K8s Secret
+  namespace: minio # Target namespace
 spec:
   provider: azure
   parameters:
     usePodIdentity: "false"
-    keyvaultName: "atomic-kv"
-    tenantId: "YOUR_TENANT_ID"
+    keyvaultName: "${KEY_VAULT_NAME}"
+    tenantId: "${TENANT_ID}"
     objects:  |
       array:
         - |
-          objectName: STORAGE-ACCESS-KEY # Name in Azure Key Vault (from terraform key_vault.tf)
-          objectType: secret
+          objectName: "STORAGE-ACCESS-KEY" # Name in Azure Key Vault (from terraform key_vault.tf)
+          objectType: "secret"
         - |
-          objectName: STORAGE-SECRET-KEY # Name in Azure Key Vault
-          objectType: secret
+          objectName: "STORAGE-SECRET-KEY" # Name in Azure Key Vault
+          objectType: "secret"
   secretObjects:
     - secretName: minio-credentials-azure # Name of the K8s Secret to create
       type: Opaque
       data:
-        # Mapping Key Vault secret names to desired K8s Secret keys
-        - objectName: STORAGE-ACCESS-KEY
-          key: MINIO_ROOT_USER # Desired key in K8s Secret for MinIO application
-        - objectName: STORAGE-SECRET-KEY
-          key: MINIO_ROOT_PASSWORD # Desired key in K8s Secret for MinIO application
+        # Mapping Key Vault secret names (via objectName) to desired K8s Secret keys
+        - objectName: "STORAGE-ACCESS-KEY"
+          key: MINIO_ROOT_USER # Key expected by the MinIO K8s deployment
+        - objectName: "STORAGE-SECRET-KEY"
+          key: MINIO_ROOT_PASSWORD # Key expected by the MinIO K8s deployment
 
 ---
 # --- SecretProviderClass for Functions Service Application Secrets (Azure) ---
@@ -69,71 +88,68 @@ apiVersion: secrets-store.csi.x-k8s.io/v1
 kind: SecretProviderClass
 metadata:
   name: functions-app-secrets-spc-azure
-  namespace: functions # Target namespace for the K8s Secret
+  namespace: functions # Target namespace
 spec:
   provider: azure
   parameters:
     usePodIdentity: "false"
-    keyvaultName: "atomic-kv"
-    tenantId: "YOUR_TENANT_ID"
+    keyvaultName: "${KEY_VAULT_NAME}"
+    tenantId: "${TENANT_ID}"
     objects:  |
       array:
         - |
-          objectName: OPENAI-API-KEY # Name in Azure Key Vault
-          objectType: secret
+          objectName: "OPENAI-API-KEY" # Name in Azure Key Vault
+          objectType: "secret"
         - |
-          objectName: HASURA-GRAPHQL-ADMIN-SECRET # Name in Azure Key Vault
-          objectType: secret
+          objectName: "HASURA-GRAPHQL-ADMIN-SECRET" # Name in Azure Key Vault
+          objectType: "secret"
         - |
-          objectName: BASIC-AUTH-FUNCTIONS-ADMIN # Name in Azure Key Vault (from terraform key_vault.tf)
-          objectType: secret
+          objectName: "BASIC-AUTH-FUNCTIONS-ADMIN" # Actual name in Key Vault (from key_vault.tf)
+          objectType: "secret"
         - |
-          objectName: GOOGLE-CLIENT-ID-ATOMIC-WEB # Name in Azure Key Vault
-          objectType: secret
+          objectName: "GOOGLE-CLIENT-ID-ATOMIC-WEB" # Name in Azure Key Vault
+          objectType: "secret"
         - |
-          objectName: ZOOM-CLIENT-SECRET # Name in Azure Key Vault
-          objectType: secret
-        # Add other secrets for the 'functions' service as needed following this pattern
-        # Example from terraform key_vault.tf:
+          objectName: "ZOOM-CLIENT-SECRET" # Name in Azure Key Vault
+          objectType: "secret"
+        # Add other secrets for the 'functions' service as needed, for example:
         # - |
-        #   objectName: API-TOKEN
-        #   objectType: secret
+        #   objectName: "API-TOKEN" # From key_vault.tf
+        #   objectType: "secret"
+        # - |
+        #   objectName: "STRIPE-API-KEY" # Assuming it's stored in KV
+        #   objectType: "secret"
 
   secretObjects:
     - secretName: functions-app-credentials-azure # Name of the K8s Secret to create
       type: Opaque
       data:
-        # These keys will be created in the K8s Secret 'functions-app-credentials-azure'
+        # These keys will be created in the K8s Secret 'functions-app-credentials-azure'.
         # The value for each key will be the content of the corresponding Azure Key Vault secret.
-        - objectName: OPENAI-API-KEY
+        - objectName: "OPENAI-API-KEY"
           key: OPENAI_API_KEY
-        - objectName: HASURA-GRAPHQL-ADMIN-SECRET
+        - objectName: "HASURA-GRAPHQL-ADMIN-SECRET"
           key: HASURA_GRAPHQL_ADMIN_SECRET
-        - objectName: BASIC-AUTH-FUNCTIONS-ADMIN # Source from Key Vault
-          key: BASIC_AUTH                         # Target key in K8s Secret, as expected by the 'functions' app
-        - objectName: GOOGLE-CLIENT-ID-ATOMIC-WEB
+        - objectName: "BASIC-AUTH-FUNCTIONS-ADMIN" # Source from Key Vault (matches objectName)
+          key: BASIC_AUTH                         # Target key in K8s Secret, as expected by the 'functions' app deployment
+        - objectName: "GOOGLE-CLIENT-ID-ATOMIC-WEB"
           key: GOOGLE_CLIENT_ID_ATOMIC_WEB
-        - objectName: ZOOM-CLIENT-SECRET
+        - objectName: "ZOOM-CLIENT-SECRET"
           key: ZOOM_CLIENT_SECRET
-        # - objectName: API-TOKEN
+        # - objectName: "API-TOKEN"
         #   key: API_TOKEN
+        # - objectName: "STRIPE-API-KEY"
+        #   key: STRIPE_API_KEY
 
-# --- Notes on Usage ---
-# 1. Ensure the Azure Key Vault Provider for Secrets Store CSI Driver is installed in your AKS cluster.
-#    This is often available as an AKS add-on.
-# 2. The identity used by the driver (e.g., Kubelet Managed Identity if `usePodIdentity: "false"` and no specific
-#    service account identity is configured for the provider) must have the "Key Vault Secrets User" role
-#    assigned on the specified Azure Key Vault (`atomic-kv` in these examples). This was set up in `key_vault.tf`.
-# 3. If using Workload Identity, `usePodIdentity: "false"` is still appropriate, and the service account
-#    for the CSI driver provider pods (or pods that need direct access if driver is not syncing to K8s secrets)
-#    would be annotated for Workload Identity. The Terraform `key_vault.tf` assigned role to `aks_kubelet_identity_object_id`.
-#    If Workload Identity is used for the CSI driver itself, that identity needs the permissions.
-# 4. Pods consume these secrets either by mounting them as volumes (pointing to the SecretProviderClass)
-#    or by referencing the Kubernetes `Secret` objects (e.g., `postgres-credentials-azure`) created by `secretObjects`.
-#    The latter allows using `envFrom` or `valueFrom` for environment variables.
-# 5. `keyvaultName` and `tenantId` must be updated to your actual Azure Key Vault name and Tenant ID.
-# 6. The `objectName` in the `objects` array must exactly match the secret name in Azure Key Vault.
-#    The Terraform `key_vault.tf` used names like "POSTGRES-PASSWORD", "STORAGE-ACCESS-KEY", etc.
-# 7. The `key` in `secretObjects.data` defines the key name within the generated Kubernetes Secret.
-#    This allows mapping from a Key Vault secret name to a different environment variable name if needed
-#    (e.g., KV "BASIC-AUTH-FUNCTIONS-ADMIN" to K8s Secret key "BASIC_AUTH").
+# --- General Notes on Usage ---
+# - The `objectName` in `parameters.objects` must exactly match the name of the secret in Azure Key Vault.
+#   The Terraform setup (deploy/azure/terraform/key_vault.tf) created secrets with hyphenated names like "POSTGRES-PASSWORD".
+# - If a secret in Azure Key Vault is a multi-line string or JSON, it will be fetched as is.
+# - Pods that need these secrets will typically reference the Kubernetes `Secret` objects
+#   (e.g., `postgres-credentials-azure`) created by `secretObjects` to populate environment variables (e.g., using `envFrom`).
+#   Alternatively, they can mount secrets directly as files using a CSI volume referencing the SecretProviderClass.
+# - Ensure that the Kubernetes Service Account used by the pods (or the default KSA of the namespace if not specified)
+#   is configured for Azure Workload Identity and linked to a GCP Service Account that has been granted
+#   "Key Vault Secrets User" permissions on the Key Vault and its secrets.
+#   (This was configured in `deploy/azure/terraform/key_vault.tf` for `var.aks_secret_accessor_identity_object_id`).
+#   Or, if the AKS Key Vault addon uses the Kubelet's Managed Identity by default, that identity needs the permissions.


### PR DESCRIPTION
This commit includes the conceptually implemented Terraform HCL code for Azure infrastructure and the Azure-specific Kustomize overlays for the 'atomic' application. This builds upon the previously completed AWS assets and common Kubernetes base manifests.

Azure Assets Implemented (Conceptual):

1.  **Terraform for Azure (`deploy/azure/terraform/`):**
    *   Networking: VNet, Subnets, Network Security Groups.
    *   AKS Cluster: Control plane, default node pool, Key Vault CSI addon enabled.
    *   ACR: Azure Container Registry with initial AKS pull permissions.
    *   Key Vault: RBAC-enabled, placeholder secrets, and RBAC for AKS Kubelet
      Managed Identity to access secrets.
    *   Azure Database for PostgreSQL: Flexible Server, VNet integrated, password
      from Key Vault.
    *   Managed Identities: User-Assigned MI for Kubelet with roles for ACR & KV.
    *   Common Files: Provider, versions (with Azure Blob backend example),
      consolidated variables, and outputs.

2.  **Azure-Specific Kustomize Overlays (`deploy/kubernetes/overlays/azure/`):**
    *   `SecretProviderClass` resources for Azure Key Vault integration via CSI driver.
    *   Patches to update Kubernetes Deployments/StatefulSets to reference secrets
      synced from Key Vault.
    *   Patches to add Azure Load Balancer annotations to the Traefik service.
    *   Main Azure overlay `kustomization.yaml` including conceptual ACR image
      overrides.

Current Status & Next Steps:
The Azure IaC and Kustomize overlays are now conceptually implemented. The next steps for Azure are to implement the deployment scripts and documentation. Following the completion of all Azure assets, I plan to proceed with GCP, then DigitalOcean, and finally the unified deployment script and top-level documentation.