### PR TITLE
refactor: Use time range for preferred meeting time

### DIFF
--- a/kotlin-quarkus/API_GUIDE.md
+++ b/kotlin-quarkus/API_GUIDE.md
@@ -79,16 +79,18 @@ When calling the `/scheduleMeeting` endpoint, your application must send a JSON 
   "participantNames": ["string (User ID/Name)", "string (User ID/Name)"], // Required: List of names or unique IDs of participants
   "durationMinutes": "number (integer)",         // Required: Duration of the meeting in minutes (e.g., 30)
   "preferredDate": "string (YYYY-MM-DD)",        // Required: Preferred date for the meeting (e.g., "2024-07-24")
-  "preferredTime": "string (HH:MM:SS)"           // Required: Preferred start time for the meeting (e.g., "14:00:00")
+  "preferredStartTimeFrom": "string (HH:MM:SS)", // Required: Preferred start of the time window for the meeting (e.g., "14:00:00")
+  "preferredStartTimeTo": "string (HH:MM:SS)"    // Required: Preferred end of the time window for the meeting (e.g., "16:00:00")
 }
 ```
 **Field Descriptions:**
 *   `participantNames`: An array of strings, where each string is a unique identifier for a user (e.g., their UUID or a unique username that can be resolved by the system).
 *   `durationMinutes`: The desired length of the meeting in minutes.
 *   `preferredDate`: The preferred date for the meeting in `YYYY-MM-DD` format. The scheduler will prioritize this date.
-*   `preferredTime`: The preferred start time for the meeting on the `preferredDate`, in `HH:MM:SS` format (24-hour clock). The scheduler will prioritize this time.
+*   `preferredStartTimeFrom`: The start of the preferred time window for the meeting to begin, in `HH:MM:SS` format (e.g., "14:00:00").
+*   `preferredStartTimeTo`: The end of the preferred time window for the meeting to begin, in `HH:MM:SS` format (e.g., "16:00:00"). The meeting should start at or before this time.
 
-The system will then attempt to find a common available slot for all participants for the given duration, trying to match the preferred date and time. The actual scheduling problem submitted to the backend solver will be constructed based on this request.
+The system will then attempt to find a common available slot for all participants for the given duration, trying to schedule the start of the meeting within the preferred date and time window. The actual scheduling problem submitted to the backend solver will be constructed based on this request.
 
 ---
 

--- a/kotlin-quarkus/src/test/kotlin/org/acme/kotlin/atomic/meeting/assist/rest/TimeTableResourceTest.kt
+++ b/kotlin-quarkus/src/test/kotlin/org/acme/kotlin/atomic/meeting/assist/rest/TimeTableResourceTest.kt
@@ -516,7 +516,8 @@ class TimeTableResourceTest {
             participantNames = listOf(sarahId.toString(), johnId.toString()), // Using UUIDs as names per current logic
             durationMinutes = 30,
             preferredDate = "2024-07-24", // Example: a Wednesday
-            preferredTime = "14:00:00"
+            preferredStartTimeFrom = "14:00:00",
+            preferredStartTimeTo = "16:00:00"
         )
 
         given()


### PR DESCRIPTION
Modify the meeting scheduling feature to accept a preferred time range (start and end) instead of an exact preferred time.

Key changes:
- Updated `ScheduleMeetingRequest` DTO to include `preferredStartTimeFrom` and `preferredStartTimeTo`.
- Modified `TimeTableResource.scheduleMeeting` to parse these fields and populate `EventPart.preferredStartTimeRange` and `EventPart.preferredEndTimeRange`.
- Adjusted constraints in `TimeTableConstraintProvider.kt`:
    - Removed `rewardPreferredMeetingTimeSoftReward` (which used exact time).
    - Reviewed and updated `notPreferredScheduleStartTimeRangeMediumPenalize` and `notPreferredScheduleEndTimeRangeMediumPenalize` to correctly penalize scheduling outside the new preferred start time window.
- Updated `TimeTableResourceTest.kt` to align with the new DTO structure.
- Updated `API_GUIDE.md` to document the new DTO fields and their usage.